### PR TITLE
Allow for relative imports to be skipped, even if the file doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ rollup({
       main: true,  // Default: true
 
       // if there's something your bundle requires that you DON'T
-      // want to include, add it to 'skip'
+      // want to include, add it to 'skip'. Local and relative imports
+      // can be skipped by giving the full filepath. E.g., 
+      // `path.resolve('src/relative-dependency.js')`
       skip: [ 'some-big-dependency' ],  // Default: []
 
       // some package.json files have a `browser` field which

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "es5-ext": "^0.10.11",
     "eslint": "^1.7.3",
     "mocha": "^2.3.3",
-    "rollup": "^0.22.0",
+    "rollup": "^0.25.7",
     "rollup-plugin-babel": "^2.2.0",
     "rollup-plugin-commonjs": "^2.0.0",
     "string-capitalize": "^1.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -23,9 +23,12 @@ export default function nodeResolve ( options ) {
 			let parts = importee.split( /[\/\\]/ );
 			let id = parts.shift();
 
-			// scoped packages
 			if ( id[0] === '@' && parts.length ) {
+				// scoped packages
 				id += `/${parts.shift()}`;
+			} else if ( id[0] === '.' ) {
+				// an import relative to the parent dir of the importer
+				id = resolve( importer, '..', importee );
 			}
 
 			if ( skip !== true && ~skip.indexOf( id ) ) return null;

--- a/test/samples/skip-nonexistent-relative/main.js
+++ b/test/samples/skip-nonexistent-relative/main.js
@@ -1,0 +1,1 @@
+import './nonexistent-relative-dependency.js';

--- a/test/test.js
+++ b/test/test.js
@@ -226,6 +226,23 @@ describe( 'rollup-plugin-node-resolve', function () {
 		});
 	});
 
+	it( 'skip: allows for a relative file to be skipped, even if the file doesn\'t exist', () => {
+		const externalFile = path.resolve( __dirname, 'samples', 'skip-nonexistent-relative', './nonexistent-relative-dependency.js' );
+		return rollup.rollup({
+			entry: 'samples/skip-nonexistent-relative/main.js',
+			external: [ externalFile ],
+			plugins: [
+				nodeResolve({
+					jsnext: true,
+					main: false,
+					skip: [ externalFile ]
+				})
+			]
+		}).then( bundle => {
+			assert.deepEqual( bundle.imports.sort(), [ './nonexistent-relative-dependency.js' ]);
+		});
+	});
+
 	it( 'skip: true allows all unfound dependencies to be skipped without error', () => {
 		return rollup.rollup({
 			entry: 'samples/skip-true/main.js',


### PR DESCRIPTION
See rollup/rollup#532 for the explanation of the problem and the
use case for skipping relative imports for files that don't exist.
This pull request, in conjunction with rollup/rollup#572, resolves the
issue.

The revving of the rollup version in the package.json is because the
new test requires rollup@^0.25.7, and npm's caret semver behavior
[does not install 0.25.x when a dependency is listed at ^0.22.0](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004).
The source code itself does not require rollup@^0.25.7, just the test.