### PR TITLE
Fix code sample in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ rollup({
     nodeResolve({ jsnext: true, main: true }),
     commonjs()
   ]
-}).then( bundle => bundle.write({ dest: 'bundle.js', format: 'iife' }) );
+}).then(bundle => bundle.write({ 
+  dest: 'bundle.js', 
+  moduleName: 'MyModule',
+  format: 'iife' 
+})).catch(err => console.log(err.stack));
 ```
 
 


### PR DESCRIPTION
1. Without `moduleName`, fails with `Error: You must supply options.moduleName for IIFE bundles`
2. Not adding the `.catch()` means these errors are silent and hard to catch.