### PR TITLE
Ensure browserResolve has a default filename

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,9 +34,7 @@ export default function nodeResolve ( options ) {
 			if ( !importer ) return null;
 
 			return new Promise( ( accept, reject ) => {
-				resolveId(
-					importee,
-					{
+				var opts = {
 						basedir: dirname( importer ),
 						packageFilter ( pkg ) {
 							if ( options.jsnext ) {
@@ -54,7 +52,18 @@ export default function nodeResolve ( options ) {
 							return pkg;
 						},
 						extensions: options.extensions
-					},
+					};
+					
+				// NOTE: https://www.npmjs.com/package/browser-resolve running in Node v6+ requires
+				// opts.filename to **not** be undefined; if we are using browserResolve, ensure that option has
+				// a default configuration value for 'filename'
+				if (options.browser) {
+					opts.filename = __filename; 
+				}
+				
+				resolveId(
+					importee,
+					opts,
 					( err, resolved ) => {
 						if ( err ) {
 							if ( skip === true ) accept( false );


### PR DESCRIPTION
Please see:

https://github.com/rollup/rollup-plugin-node-resolve/issues/38
and
https://github.com/defunctzombie/node-browser-resolve/pull/80

for how Node v6+ throws a TypeError if `path.dirname` is passed an undefined value.  `node-browser-resolve` currently does not use set a default value if it's `opts.filename` is not specified resulting in the following stack trace:
```javascript
[19:40:45] TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.dirname (path.js:1324:5)
    at resolve (/my_app/node_modules/browser-resolve/index.js:218:21)
    at /my_app/node_modules/rollup-plugin-node-resolve/dist/rollup-plugin-node-resolve.cjs.js:46:5
    at resolveId (/my_app/node_modules/rollup-plugin-node-resolve/dist/rollup-plugin-node-resolve.cjs.js:45:11)
    at /my_app/node_modules/rollup/dist/rollup.js:2123:32
    at tryCatch (/my_app/node_modules/rollup/dist/rollup.js:393:12)
    at invokeCallback (/my_app/node_modules/rollup/dist/rollup.js:405:13)
    at publish (/my_app/node_modules/rollup/dist/rollup.js:376:7)
    at flush (/my_app/node_modules/rollup/dist/rollup.js:120:5)
```