### PR TITLE
Use any-promise to find Promise implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "README.md"
   ],
   "dependencies": {
+    "any-promise": "^1.3.0",
     "browser-resolve": "^1.11.0",
     "builtin-modules": "^1.1.0",
     "resolve": "^1.1.6"

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import { dirname, resolve } from 'path';
 import builtins from 'builtin-modules';
 import _nodeResolve from 'resolve';
 import browserResolve from 'browser-resolve';
+import Promise from 'any-promise';
 
 const COMMONJS_BROWSER_EMPTY = _nodeResolve.sync( 'browser-resolve/empty.js', __dirname );
 const ES6_BROWSER_EMPTY = resolve( __dirname, '../src/empty.js' );


### PR DESCRIPTION
There are still some libraries that want / need to support Node 0.10 which lacks native support. With `any-promise` this can be easily solved.