### PR TITLE
Avoid sending undefined to path.resolve

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,10 @@ export default function nodeResolve ( options ) {
 
 		resolveId ( importee, importer ) {
 			if ( /\0/.test( importee ) ) return null; // ignore IDs with null character, these belong to other plugins
-
+		
+			// disregard entry module
+			if ( !importer ) return null;
+		
 			let parts = importee.split( /[\/\\]/ );
 			let id = parts.shift();
 
@@ -36,9 +39,6 @@ export default function nodeResolve ( options ) {
 			}
 
 			if ( skip !== true && ~skip.indexOf( id ) ) return null;
-
-			// disregard entry module
-			if ( !importer ) return null;
 
 			return new Promise( ( accept, reject ) => {
 				resolveId(


### PR DESCRIPTION
As per [Node docs](https://nodejs.org/api/path.html#path_path_resolve_path) if you give an `undefined` value to `path.resolve` it throws a TypeError. This change prevents this error by checking if `importee` is undefined in `resolveId` before sending it to `path.resolve`.

```
TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.resolve (path.js:1148:7)
```