### PR TITLE
Add a jail feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ rollup({
 
       // if there's something your bundle requires that you DON'T
       // want to include, add it to 'skip'. Local and relative imports
-      // can be skipped by giving the full filepath. E.g., 
+      // can be skipped by giving the full filepath. E.g.,
       // `path.resolve('src/relative-dependency.js')`
       skip: [ 'some-big-dependency' ],  // Default: []
 
@@ -50,7 +50,11 @@ rollup({
       // whether to prefer built-in modules (e.g. `fs`, `path`) or
       // local ones with the same names
       preferBuiltins: false  // Default: true
-      
+
+      // Lock the module search in this path (like a chroot). Module defined
+      // outside this path will be mark has external
+      jail: '/my/jail/path' // Default: '/'
+
     })
   ]
 }).then( bundle => bundle.write({ dest: 'bundle.js', format: 'iife' }) );
@@ -64,10 +68,10 @@ rollup({
     nodeResolve({ jsnext: true, main: true }),
     commonjs()
   ]
-}).then(bundle => bundle.write({ 
-  dest: 'bundle.js', 
+}).then(bundle => bundle.write({
+  dest: 'bundle.js',
   moduleName: 'MyModule',
-  format: 'iife' 
+  format: 'iife'
 })).catch(err => console.log(err.stack));
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { dirname, resolve, normalize } from 'path';
+import { dirname, resolve, normalize, sep } from 'path';
 import builtins from 'builtin-modules';
 import _nodeResolve from 'resolve';
 import browserResolve from 'browser-resolve';
@@ -16,6 +16,7 @@ export default function nodeResolve ( options ) {
 	const useMain = options.main !== false;
 	const isPreferBuiltinsSet = options.preferBuiltins === true || options.preferBuiltins === false;
 	const preferBuiltins = isPreferBuiltinsSet ? options.preferBuiltins : true;
+	const jail = options.jail || '/';
 
 	const onwarn = options.onwarn || CONSOLE_WARN;
 	const resolveId = options.browser ? browserResolve : _nodeResolve;
@@ -80,6 +81,8 @@ export default function nodeResolve ( options ) {
 										`behavior or 'preferBuiltins: true' to disable this warning`
 									);
 								}
+								accept( null );
+							} else if (resolved.indexOf(normalize(jail.trim(sep))) !== 0) {
 								accept( null );
 							} else {
 								accept( resolved );

--- a/test/samples/jail/main.js
+++ b/test/samples/jail/main.js
@@ -1,0 +1,3 @@
+import uppercase from 'string/uppercase.js';
+
+export default uppercase( 'foo' );

--- a/test/test.js
+++ b/test/test.js
@@ -415,4 +415,26 @@ describe( 'rollup-plugin-node-resolve', function () {
 			assert.equal( err.message, 'Could not resolve \'foo\' from ' + path.resolve( __dirname, entry ) );
 		});
 	});
+
+	it( 'mark as external to module outside the jail', () => {
+		return rollup.rollup({
+			entry: 'samples/jail/main.js',
+			plugins: [ nodeResolve({
+				jail: `${__dirname}/samples/`
+			}) ]
+		}).then( (bundle) => {
+			assert.deepEqual(bundle.imports, [ 'string/uppercase.js' ]);
+		});
+	});
+
+	it( 'bundle module defined inside the jail', () => {
+		return rollup.rollup({
+			entry: 'samples/jail/main.js',
+			plugins: [ nodeResolve({
+				jail: `${__dirname}/`
+			}) ]
+		}).then( (bundle) => {
+			assert.deepEqual(bundle.imports, []);
+		});
+	});
 });


### PR DESCRIPTION
Like we discuss the other day on gitter. If you think this feature as not is place in this plugin you can close this PR. 

This PR a `chroot` like feature. If a module is defined outside the `jail`, it will be marked as external and not bundled.
