### PR TITLE
Support modules.root

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { dirname, resolve, normalize } from 'path';
+import { dirname, resolve, normalize, join } from 'path';
 import builtins from 'builtin-modules';
 import _nodeResolve from 'resolve';
 import browserResolve from 'browser-resolve';
@@ -11,6 +11,7 @@ export default function nodeResolve ( options = {} ) {
 	const skip = options.skip || [];
 	const useJsnext = options.jsnext === true;
 	const useModule = options.module !== false;
+	const useModulesRoot = options.modulesRoot !== false;
 	const useMain = options.main !== false;
 	const isPreferBuiltinsSet = options.preferBuiltins === true || options.preferBuiltins === false;
 	const preferBuiltins = isPreferBuiltinsSet ? options.preferBuiltins : true;
@@ -58,6 +59,9 @@ export default function nodeResolve ( options = {} ) {
 								else reject( Error( `Package ${importee} (imported by ${importer}) does not have a module or jsnext:main field. You should either allow legacy modules with options.main, or skip it with options.skip = ['${importee}'])` ) );
 							}
 							return pkg;
+						},
+						pathFilter ( pkg, path, relativePath ) {
+							return ( useModulesRoot && relativePath && pkg['modules.root'] ) ? join(pkg['modules.root'], relativePath) : '';
 						},
 						extensions: options.extensions
 					},

--- a/test/node_modules/modules.root/lib/sub.js
+++ b/test/node_modules/modules.root/lib/sub.js
@@ -1,0 +1,1 @@
+export default 'SUBMODULE';

--- a/test/node_modules/modules.root/package.json
+++ b/test/node_modules/modules.root/package.json
@@ -1,0 +1,3 @@
+{
+	"modules.root": "lib"
+}

--- a/test/samples/modules.root/main.js
+++ b/test/samples/modules.root/main.js
@@ -1,0 +1,3 @@
+import submodule from 'modules.root/sub';
+
+export default submodule; // SUBMODULE

--- a/test/test.js
+++ b/test/test.js
@@ -355,6 +355,17 @@ describe( 'rollup-plugin-node-resolve', function () {
 		});
 	});
 
+	it( 'finds a submodule with modules.root field', () => {
+		return rollup.rollup({
+			entry: 'samples/modules.root/main.js',
+			plugins: [
+				nodeResolve({ preferBuiltins: false })
+			]
+		}).then( executeBundle ).then( module => {
+			assert.equal( module.exports, 'SUBMODULE' );
+		});
+	});
+
 	it( 'prefers module field over jsnext:main and main', () => {
 		return rollup.rollup({
 			entry: 'samples/prefer-module/main.js',


### PR DESCRIPTION
This supports `modules.root` property according to "[In Defense of .js](https://github.com/dherman/defense-of-dot-js/blob/master/proposal.md#proposal)". It's not a standard yet, but It seems the only way to resolve path to sub modules.

If we have a package like below:

- index.js - *main module for cjs*
- sub.js - *sub module for cjs*
- module.js - *main module for es6*
- lib/
  - sub.js - *sub module for es6*

with `package.json` like this:

```json
{
  "module": "module.js",
  "modules.root": "lib"
}
```

then we can resolve this:

```javascript
import submodule from 'module/sub'
```

I've added `opts.modulesRoot` and made it default `true` like `opts.module` in #49. So note that it needs major release. Thanks!