### PR TITLE
Add fix to symlinked packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4"
   - "6"
 env:

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import { dirname, resolve, normalize } from 'path';
 import builtins from 'builtin-modules';
 import _nodeResolve from 'resolve';
 import browserResolve from 'browser-resolve';
+import fs from 'fs';
 
 const COMMONJS_BROWSER_EMPTY = _nodeResolve.sync( 'browser-resolve/empty.js', __dirname );
 const ES6_BROWSER_EMPTY = resolve( __dirname, '../src/empty.js' );
@@ -62,6 +63,10 @@ export default function nodeResolve ( options = {} ) {
 						extensions: options.extensions
 					},
 					( err, resolved ) => {
+						if ( resolved && fs.existsSync( resolved ) ) {
+							resolved = fs.realpathSync( resolved );
+						}
+
 						if ( err ) {
 							if ( skip === true ) accept( false );
 							else reject( Error( `Could not resolve '${importee}' from ${normalize( importer )}` ) );

--- a/test/samples/symlinked/first/index.js
+++ b/test/samples/symlinked/first/index.js
@@ -1,0 +1,2 @@
+export { default as number1 } from 'second';
+export { default as number2 } from 'third';

--- a/test/samples/symlinked/second/index.js
+++ b/test/samples/symlinked/second/index.js
@@ -1,0 +1,3 @@
+import randomNumber from 'third';
+
+export default randomNumber;

--- a/test/samples/symlinked/third/index.js
+++ b/test/samples/symlinked/third/index.js
@@ -1,0 +1,3 @@
+const randomNumber = Math.random();
+
+export default randomNumber;

--- a/test/test.js
+++ b/test/test.js
@@ -377,8 +377,7 @@ describe( 'rollup-plugin-node-resolve', function () {
 				nodeResolve()				
 			]
 		}).then( executeBundle ).then( module => {
-			const { number1, number2 } = module.exports;
-			assert.equal( number1, number2 );
+			assert.equal( module.exports.number1, module.exports.number2 );
 		}).then(() => { 
 			unlinkDirectories();
 		}).catch(err => { 

--- a/test/test.js
+++ b/test/test.js
@@ -368,6 +368,7 @@ describe( 'rollup-plugin-node-resolve', function () {
 	});
 
 	it( 'resolves symlinked packages', () => {
+		createMissingDirectories();
 		linkDirectories();
 
 		return rollup.rollup({
@@ -384,6 +385,18 @@ describe( 'rollup-plugin-node-resolve', function () {
 			unlinkDirectories();
 			throw err;
 		});
+
+		function createMissingDirectories () {
+			createDirectory( './samples/symlinked/first/node_modules' );
+			createDirectory( './samples/symlinked/second/node_modules' );
+			createDirectory( './samples/symlinked/third/node_modules' );
+		}
+
+		function createDirectory ( pathToDir ) { 
+			if ( !fs.existsSync( pathToDir ) ) {
+				fs.mkdirSync( pathToDir );
+			}
+		}
 
 		function linkDirectories () {
 			fs.symlinkSync('../../second', './samples/symlinked/first/node_modules/second', 'dir');


### PR DESCRIPTION
This pull request fixes https://github.com/rollup/rollup-plugin-node-resolve/issues/67.

Fix adds support for the symlinked packages which are used by [Lerna](https://github.com/lerna/lerna) and some other multi-package tools.

I'm not sure whether these [lines](https://github.com/rollup/rollup-plugin-node-resolve/compare/master...ma2ciek:master#diff-1fdf421c05c1140f6d71444ea2b27638R66) can be improved. If yes, please give me some insight about the cases that this improvement doesn't solve.

I added pretty simple [test](https://github.com/rollup/rollup-plugin-node-resolve/compare/master...ma2ciek:master#diff-c1129c8b045390789fa8ff62f2c6b4a9R370) which describes the problem very well. 

**The solved problem:**
Package A requires B and C
Package B requires C
All packages are symlinked between each other.

Now references to files in package C differs between A and B which breaks e.g singletons, instanceof checks and equality checks.

Thanks!