### PR TITLE
Adding an "only" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ export default {
       // Lock the module search in this path (like a chroot). Module defined
       // outside this path will be marked as external
       jail: '/my/jail/path', // Default: '/'
+      
+      // Set to an array of strings and/or regexps to lock the module search
+      // to modules that match at least one entry. Modules not matching any
+      // entry will be marked as external
+      only: [ 'some_module', /^@some_scope\/.*$/ ], // Default: null
 
       // If true, inspect resolved files to check that they are
       // ES2015 modules

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ export default function nodeResolve ( options = {} ) {
 	const preferBuiltins = isPreferBuiltinsSet ? options.preferBuiltins : true;
 	const customResolveOptions = options.customResolveOptions || {};
 	const jail = options.jail;
+	const only = options.only;
 	const browserMapCache = {};
 
 	const onwarn = options.onwarn || CONSOLE_WARN;
@@ -98,6 +99,8 @@ export default function nodeResolve ( options = {} ) {
 				// an import relative to the parent dir of the importer
 				id = resolve( importer, '..', importee );
 			}
+
+			if (only && !only.some(pattern => id.match(pattern))) return null;
 
 			return new Promise( ( fulfil, reject ) => {
 				let disregardResult = false;

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,12 @@ export default function nodeResolve ( options = {} ) {
 	const preferBuiltins = isPreferBuiltinsSet ? options.preferBuiltins : true;
 	const customResolveOptions = options.customResolveOptions || {};
 	const jail = options.jail;
-	const only = options.only;
+	const only = Array.isArray(options.only)
+		? options.only.map(o => o instanceof RegExp
+			? o
+			: new RegExp('^' + String(o).replace(/[\\^$*+?.()|[\]{}]/g, '\\$&') + '$')
+		)
+		: null;
 	const browserMapCache = {};
 
 	const onwarn = options.onwarn || CONSOLE_WARN;
@@ -100,7 +105,7 @@ export default function nodeResolve ( options = {} ) {
 				id = resolve( importer, '..', importee );
 			}
 
-			if (only && !only.some(pattern => id.match(pattern))) return null;
+			if (only && !only.some(pattern => pattern.test(id))) return null;
 
 			return new Promise( ( fulfil, reject ) => {
 				let disregardResult = false;

--- a/test/node_modules/@scoped/bar/index.js
+++ b/test/node_modules/@scoped/bar/index.js
@@ -1,0 +1,1 @@
+export default 'BAR';

--- a/test/samples/only/main.js
+++ b/test/samples/only/main.js
@@ -1,0 +1,7 @@
+import foo from '@scoped/foo';
+import bar from '@scoped/bar';
+import test from 'test';
+
+console.log( foo );
+console.log( bar );
+console.log( test );

--- a/test/test.js
+++ b/test/test.js
@@ -552,6 +552,32 @@ describe( 'rollup-plugin-node-resolve', function () {
 		});
 	});
 
+	it( '"only" option allows to specify the only packages to resolve', () => {
+		return rollup.rollup({
+			input: 'samples/only/main.js',
+			plugins: [
+				nodeResolve({
+					only: [ 'test' ]
+				})
+			]
+		}).then(bundle => {
+			assert.deepEqual( bundle.imports.sort(), [ '@scoped/bar', '@scoped/foo' ] );
+		});
+	});
+
+	it( '"only" option works with a regex', () => {
+		return rollup.rollup({
+			input: 'samples/only/main.js',
+			plugins: [
+				nodeResolve({
+					only: [ /^@scoped\/.*$/ ]
+				})
+			]
+		}).then(bundle => {
+			assert.deepEqual( bundle.imports.sort(), [ 'test' ] );
+		});
+	});
+
 	it( 'allows custom options', () => {
 		return rollup.rollup({
 			input: 'samples/custom-resolve-options/main.js',


### PR DESCRIPTION
Hello,
However, for my project, I needed the ability to limit the resolution of node_modules to only modules matching a pattern, so I added this option. The implementation is very straightforward, using `String.prototype.match`.

Using it is very simple. It works with both strings and regexes:

```javascript
{
  entry: 'samples/only/main.js',
  plugins: [
    nodeResolve({
      only: [ 'test' ]
    })
  ]
}
```

```javascript
import test from 'test' // will be bundled
import test2 from 'test2' // /!\ will be bundled
import mytest from 'mytest' // will NOT be bundled
```

```javascript
{
  entry: 'samples/only/main.js',
  plugins: [
    nodeResolve({
      only: [ /@scoped\/.*/ ]
    })
  ]
}
```
```javascript
import test from 'test' // will NOT bundled
import mytest from '@scoped/mytest' // will be bundled
import mytest2 from '@otherscope/mytest' // will NOT be bundled
```