### PR TITLE
[BREAKING] Remove options.skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,17 @@ npm install --save-dev rollup-plugin-node-resolve
 ## Usage
 
 ```js
+// rollup.config.js
 import { rollup } from 'rollup';
-import nodeResolve from 'rollup-plugin-node-resolve';
+import resolve from 'rollup-plugin-node-resolve';
 
-rollup({
+export default {
   entry: 'main.js',
+  dest: 'bundle.js',
+  moduleName: 'MyModule',
+  format: 'iife'
   plugins: [
-    nodeResolve({
+    resolve({
       // use "module" field for ES6 module if possible
       module: true, // Default: true
 
@@ -53,26 +57,38 @@ rollup({
 
       // Lock the module search in this path (like a chroot). Module defined
       // outside this path will be mark has external
-      jail: '/my/jail/path' // Default: '/'
+      jail: '/my/jail/path', // Default: '/'
 
+      // Any additional options that should be passed through
+      // to node-resolve
+      customResolveOptions: {
+        moduleDirectory: 'js_modules'
+      }
     })
   ]
-}).then( bundle => bundle.write({ dest: 'bundle.js', format: 'iife' }) );
+};
+```
 
-// alongside rollup-plugin-commonjs, for using non-ES6 third party modules
+## Using with rollup-plugin-commonjs
+
+Since most packages in your node_modules folder are probably legacy CommonJS rather than JavaScript modules, you may need to use [rollup-plugin-commonjs](https://github.com/rollup/rollup-plugin-commonjs):
+
+```js
+// rollup.config.js
+import { rollup } from 'rollup';
+import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 
-rollup({
+export default {
   entry: 'main.js',
-  plugins: [
-    nodeResolve({ jsnext: true, main: true }),
-    commonjs()
-  ]
-}).then(bundle => bundle.write({
   dest: 'bundle.js',
   moduleName: 'MyModule',
   format: 'iife'
-})).catch(err => console.log(err.stack));
+  plugins: [
+    resolve({ jsnext: true, main: true }),
+    commonjs()
+  ]
+};
 ```
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ export default function nodeResolve ( options = {} ) {
 				id = resolve( importer, '..', importee );
 			}
 
-			return new Promise( ( accept, reject ) => {
+			return new Promise( fulfil => {
 				let disregardResult = false;
 
 				resolveId(
@@ -68,17 +68,15 @@ export default function nodeResolve ( options = {} ) {
 						extensions: options.extensions
 					}, customResolveOptions ),
 					( err, resolved ) => {
-						if ( resolved && fs.existsSync( resolved ) ) {
-							resolved = fs.realpathSync( resolved );
-						}
+						if ( !disregardResult && !err ) {
+							if ( resolved && fs.existsSync( resolved ) ) {
+								resolved = fs.realpathSync( resolved );
+							}
 
-						if ( err ) {
-							accept( null );
-						} else {
 							if ( resolved === COMMONJS_BROWSER_EMPTY ) {
-								accept( ES6_BROWSER_EMPTY );
+								fulfil( ES6_BROWSER_EMPTY );
 							} else if ( ~builtins.indexOf( resolved ) ) {
-								accept( null );
+								fulfil( null );
 							} else if ( ~builtins.indexOf( importee ) && preferBuiltins ) {
 								if ( !isPreferBuiltinsSet ) {
 									onwarn(
@@ -87,15 +85,13 @@ export default function nodeResolve ( options = {} ) {
 										`behavior or 'preferBuiltins: true' to disable this warning`
 									);
 								}
-								accept( null );
+								fulfil( null );
 							} else if ( resolved.indexOf( normalize( jail.trim( sep ) ) ) !== 0 ) {
-								accept( null );
-							} else if ( disregardResult ) {
-								accept( null );
-							} else {
-								accept( resolved );
+								fulfil( null );
 							}
 						}
+
+						fulfil( resolved );
 					}
 				);
 			});

--- a/test/samples/skip-nonexistent-relative/main.js
+++ b/test/samples/skip-nonexistent-relative/main.js
@@ -1,1 +1,0 @@
-import './nonexistent-relative-dependency.js';

--- a/test/samples/skip-true/main.js
+++ b/test/samples/skip-true/main.js
@@ -1,9 +1,0 @@
-import jsnext from 'jsnext';
-import module from 'module';
-import legacy from 'legacy';
-import missing from 'missing';
-
-console.log( jsnext );
-console.log( module );
-console.log( legacy );
-console.log( missing );

--- a/test/samples/skip/main.js
+++ b/test/samples/skip/main.js
@@ -1,2 +1,0 @@
-import 'vlq';
-import 'vlq/src/vlq';

--- a/test/test.js
+++ b/test/test.js
@@ -335,20 +335,6 @@ describe( 'rollup-plugin-node-resolve', function () {
 		});
 	});
 
-	it( 'throws error if global id is not resolved', () => {
-		const entry = 'samples/unresolved-global/main.js';
-		return rollup.rollup({
-			entry,
-			plugins: [
-				nodeResolve()
-			]
-		}).then( () => {
-			throw Error( 'test should fail' );
-		}, err => {
-			assert.equal( err.message, 'Could not resolve \'foo\' from ' + path.resolve( __dirname, entry ).split( '/' ).join( path.sep )  );
-		});
-	});
-
 	it( 'mark as external to module outside the jail', () => {
 		return rollup.rollup({
 			entry: 'samples/jail/main.js',

--- a/test/test.js
+++ b/test/test.js
@@ -95,24 +95,6 @@ describe( 'rollup-plugin-node-resolve', function () {
 		});
 	});
 
-	it( 'allows skipping by package name', function () {
-		return rollup.rollup({
-			entry: 'samples/skip/main.js',
-			plugins: [
-				nodeResolve({
-					main: true,
-					skip: [ 'vlq' ]
-				})
-			]
-		}).then( function ( bundle ) {
-			const generated = bundle.generate({
-				format: 'cjs'
-			});
-
-			assert.ok( generated.code.indexOf( 'encode' ) < 0 );
-		});
-	});
-
 	it( 'disregards top-level browser field by default', function () {
 		return rollup.rollup({
 			entry: 'samples/browser/main.js',
@@ -183,99 +165,6 @@ describe( 'rollup-plugin-node-resolve', function () {
 				})
 			]
 		}).then( executeBundle );
-	});
-
-	it( 'skips builtins', function () {
-		return rollup.rollup({
-			entry: 'samples/builtins/main.js',
-			plugins: [ nodeResolve() ]
-		}).then( bundle => {
-			const { code } = bundle.generate({ format: 'cjs' });
-			const fn = new Function ( 'module', 'exports', 'require', code );
-
-			fn( module, module.exports, id => require( id ) );
-
-			assert.equal( module.exports, path.sep );
-		});
-	});
-
-	it( 'allows scoped packages to be skipped', () => {
-		return rollup.rollup({
-			entry: 'samples/scoped/main.js',
-			plugins: [
-				nodeResolve({
-					skip: [ '@scoped/foo' ]
-				})
-			]
-		}).then( bundle => {
-			assert.deepEqual( bundle.imports.sort(), [ '@scoped/foo' ]);
-		});
-	});
-
-	it( 'skip: true allows all unfound non-jsnext:main dependencies to be skipped without error', () => {
-		return rollup.rollup({
-			entry: 'samples/skip-true/main.js',
-			plugins: [
-				nodeResolve({
-					jsnext: true,
-					module: false,
-					main: false,
-					skip: true
-				})
-			]
-		}).then( bundle => {
-			assert.deepEqual( bundle.imports.sort(), [ 'legacy', 'missing', 'module' ]);
-		});
-	});
-
-	it( 'skip: true allows all unfound non-module dependencies to be skipped without error', () => {
-		return rollup.rollup({
-			entry: 'samples/skip-true/main.js',
-			plugins: [
-				nodeResolve({
-					jsnext: false,
-					module: true,
-					main: false,
-					skip: true,
-					preferBuiltins: false
-				})
-			]
-		}).then( bundle => {
-			assert.deepEqual( bundle.imports.sort(), [ 'jsnext', 'legacy', 'missing' ]);
-		});
-	});
-
-	it( 'skip: allows for a relative file to be skipped, even if the file doesn\'t exist', () => {
-		const externalFile = path.resolve( __dirname, 'samples/skip-nonexistent-relative/nonexistent-relative-dependency.js' );
-		return rollup.rollup({
-			entry: 'samples/skip-nonexistent-relative/main.js',
-			external: [ externalFile ],
-			plugins: [
-				nodeResolve({
-					jsnext: true,
-					main: false,
-					skip: [ externalFile ]
-				})
-			]
-		}).then( bundle => {
-			assert.deepEqual( bundle.imports.sort(), [ externalFile ]);
-		});
-	});
-
-	it( 'skip: true allows all unfound dependencies to be skipped without error', () => {
-		return rollup.rollup({
-			entry: 'samples/skip-true/main.js',
-			plugins: [
-				nodeResolve({
-					jsnext: false,
-					main: false,
-					module: false,
-					skip: true
-				})
-			]
-		}).then( bundle => {
-			assert.deepEqual( bundle.imports.sort(), [ 'jsnext', 'legacy', 'missing', 'module' ] );
-		});
 	});
 
 	it( 'preferBuiltins: true allows preferring a builtin to a local module of the same name', () => {
@@ -374,13 +263,13 @@ describe( 'rollup-plugin-node-resolve', function () {
 		return rollup.rollup({
 			entry: 'samples/symlinked/first/index.js',
 			plugins: [
-				nodeResolve()				
+				nodeResolve()
 			]
 		}).then( executeBundle ).then( module => {
 			assert.equal( module.exports.number1, module.exports.number2 );
-		}).then(() => { 
+		}).then(() => {
 			unlinkDirectories();
-		}).catch(err => { 
+		}).catch(err => {
 			unlinkDirectories();
 			throw err;
 		});
@@ -391,7 +280,7 @@ describe( 'rollup-plugin-node-resolve', function () {
 			createDirectory( './samples/symlinked/third/node_modules' );
 		}
 
-		function createDirectory ( pathToDir ) { 
+		function createDirectory ( pathToDir ) {
 			if ( !fs.existsSync( pathToDir ) ) {
 				fs.mkdirSync( pathToDir );
 			}
@@ -442,21 +331,7 @@ describe( 'rollup-plugin-node-resolve', function () {
 		}).then( () => {
 			throw Error( 'test should fail' );
 		}, err => {
-			assert.equal( err.message, 'Could not resolve \'./foo\' from ' + path.resolve( __dirname, entry ) );
-		});
-	});
-
-	it( 'throws error if global id is not resolved', () => {
-		const entry = 'samples/unresolved-global/main.js';
-		return rollup.rollup({
-			entry,
-			plugins: [
-				nodeResolve()
-			]
-		}).then( () => {
-			throw Error( 'test should fail' );
-		}, err => {
-			assert.equal( err.message, 'Could not resolve \'foo\' from ' + path.resolve( __dirname, entry ) );
+			assert.equal( err.message, `Could not resolve './foo' from ${entry}` );
 		});
 	});
 


### PR DESCRIPTION
The `skip` option is confusing and (as far as I can tell) unnecessary. People are better off using the `external` option in the main Rollup config. Prompted by https://github.com/Rich-Harris/packd/issues/2, I'm toying with the idea of removing it. Any objections?