### PR TITLE
error message: externals -> external

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ export default function nodeResolve ( options = {} ) {
 	const resolveId = options.browser ? browserResolve : _nodeResolve;
 
 	if ( options.skip ) {
-		throw new Error( 'options.skip is no longer supported — you should use the main Rollup `externals` option instead' );
+		throw new Error( 'options.skip is no longer supported — you should use the main Rollup `external` option instead' );
 	}
 
 	if ( !useModule && !useMain && !useJsnext ) {


### PR DESCRIPTION
Following the error advice will give you follow-up error

`Error: Unexpected key 'externals' found, expected one of: acorn, banner, cache, context, dest, entry, exports, external, ...`

So, I guess it should say `external` instead