### PR TITLE
use enhanced-resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,9 @@
     "dist"
   ],
   "dependencies": {
-    "browser-resolve": "^1.11.0",
     "builtin-modules": "^1.1.0",
-    "is-module": "^1.0.0",
-    "resolve": "^1.1.6"
+    "enhanced-resolve": "^3.1.0",
+    "is-module": "^1.0.0"
   },
   "repository": "rollup/rollup-plugin-node-resolve",
   "keywords": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,7 @@ import buble from 'rollup-plugin-buble';
 export default {
 	entry: 'src/index.js',
 	plugins: [ buble() ],
-	external: [ 'path', 'fs', 'builtin-modules', 'resolve', 'browser-resolve', 'is-module' ],
+	external: [ 'path', 'fs', 'builtin-modules', 'enhanced-resolve', 'is-module' ],
 	targets: [
 		{ dest: 'dist/rollup-plugin-node-resolve.cjs.js', format: 'cjs' },
 		{ dest: 'dist/rollup-plugin-node-resolve.es.js', format: 'es' }

--- a/test/test.js
+++ b/test/test.js
@@ -362,7 +362,7 @@ describe( 'rollup-plugin-node-resolve', function () {
 			entry: 'samples/custom-resolve-options/main.js',
 			plugins: [ nodeResolve({
 				customResolveOptions: {
-					moduleDirectory: 'js_modules'
+					modules: ['js_modules']
 				}
 			}) ]
 		}).then( bundle => {


### PR DESCRIPTION
This PR replaces `node-resolve` and `browser-resolve` with `enhanced-resolve`, which is more abstract and configurable.

My use case is to produce bundles for both browsers and react-native. I want to specify `["react-native", "browser"]` for aliasFields to indicate to the plugin to follow aliases in such order. But it's not supported by `browser-resolve`.

All the options should be backward compatible except for `customResolveOptions` as it will be passed to `enhanced-resolve` now. So it's a breaking change.