### PR TITLE
Correct typo in options.skip deprecation error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ export default function nodeResolve ( options = {} ) {
 	const resolveId = options.browser ? browserResolve : _nodeResolve;
 
 	if ( options.skip ) {
-		throw new Error( 'options.skip is no longer supported — you should use the main Rollup `externals` option instead' );
+		throw new Error( 'options.skip is no longer supported — you should use the main Rollup `external` option instead' );
 	}
 
 	if ( !useModule && !useMain && !useJsnext ) {


### PR DESCRIPTION
The error message when the plugin is passed options.skip was
telling users to "use the main Rollup `externals` option instead".

Doing this makes rollup throw an `Unexpected key 'externals' found`
error, as the option required by rollup is `external`.