### PR TITLE
Remove unnecessary id generation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,18 +37,7 @@ export default function nodeResolve ( options = {} ) {
 
 			// disregard entry module
 			if ( !importer ) return null;
-
-			const parts = importee.split( /[\/\\]/ );
-			let id = parts.shift();
-
-			if ( id[0] === '@' && parts.length ) {
-				// scoped packages
-				id += `/${parts.shift()}`;
-			} else if ( id[0] === '.' ) {
-				// an import relative to the parent dir of the importer
-				id = resolve( importer, '..', importee );
-			}
-
+			
 			return new Promise( ( fulfil, reject ) => {
 				let disregardResult = false;
 


### PR DESCRIPTION
This code was used alongside `options.skip`, but that is no longer supported, so this code does appears to do nothing useful. The tests were unaffected and there were no other references to the `parts` or `id` variables.