### PR TITLE
refactor: remove browser-resolve dependency, inline logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "dist"
   ],
   "dependencies": {
-    "browser-resolve": "^1.11.0",
     "builtin-modules": "^1.1.0",
     "is-module": "^1.0.0",
     "resolve": "^1.1.6"


### PR DESCRIPTION
This PR removes `browser-resolve` as a dependency, inlining the logic steps it makes. It does this for a few reasons:

 1. browser-resolve is very ineficient on disk, it does lots of lookups using its own internal mechanisms where it could rely on `resolve` more.
 2. Similar to point 1 - browser-resolve duplicates a lot of code from `resolve`. Dropping this dependency means shipping less code.
 3. While I _could have_ made a PR to `browser-resolve` to fix the above issues - doing so would reduce `browser-resolve` down to a few LOC, and I'm not sure it is under active maintainence. There are open PRs from a few years ago. I figured it would be best to move the few LOC it needs into this module.

/cc @mislav who has been working with me on this today.