### PR TITLE
fix: add guard for options.browser with no pkg.browser field

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ export default function nodeResolve ( options = {} ) {
 
 							if (options.browser && typeof pkg[ 'browser' ] === 'string') {
 								pkg[ 'main' ] = pkg[ 'browser' ];
-							} else if (options.browser && pkg[ 'browser' ][ pkg[ 'main' ] ]) {
+							} else if (options.browser && typeof pkg[ 'browser' ] === 'object' && pkg[ 'browser' ][ pkg[ 'main' ] ]) {
 								pkg[ 'main' ] = pkg[ 'browser' ][ pkg[ 'main' ] ];
 							} else if ( useModule && pkg[ 'module' ] ) {
 								pkg[ 'main' ] = pkg[ 'module' ];


### PR DESCRIPTION
This adds a fix for the problem described in https://github.com/rollup/rollup-plugin-node-resolve/pull/127#issuecomment-356690466