### PR TITLE
Fix resolve  pkg.browser failed when transform a path within a package

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = tab
+indent_size = 2

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,33 @@ export default function nodeResolve ( options = {} ) {
 							}
 							return pkg;
 						},
+						pathFilter ( pkg, resvPath, relativePath ) {
+							let mappedPath;
+							if (options.pathFilter) {
+								mappedPath = options.pathFilter.apply(this, arguments);
+							}
+							if (mappedPath) {
+								return mappedPath;
+							}
+
+							const replacements = options.browser && pkg.browser;
+							if (!replacements) {
+								return;
+							}
+
+							if (relativePath[0] != '.') {
+								relativePath = './' + relativePath;
+							}
+							mappedPath = replacements[relativePath];
+							if (!mappedPath && !extname(relativePath)) {
+								mappedPath = replacements[relativePath + '.js'];
+								if (!mappedPath) {
+									mappedPath = replacements[relativePath + '.json'];
+								}
+							}
+
+							return mappedPath;
+						},
 						extensions: options.extensions
 					}, customResolveOptions ),
 					( err, resolved ) => {


### PR DESCRIPTION
After upgrade to 3.0.1+, This pr fixing package dependent which mapping not resolved correctly.

ref: axios/package.json
```
  "browser": {
    "./lib/adapters/http.js": "./lib/adapters/xhr.js"
  },
```