### PR TITLE
Add "prepare" script for github installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
     "pretest": "npm run build",
     "test": "mocha",
     "posttest": "eslint src test/*.js",
-    "prepublish": "npm test",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "prepublishOnly": "npm test",
+    "prepare": "npm run build"
   },
   "files": [
     "src",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,11 +1,11 @@
 import buble from 'rollup-plugin-buble';
 
 export default {
-	entry: 'src/index.js',
+	input: 'src/index.js',
 	plugins: [ buble() ],
 	external: [ 'path', 'fs', 'builtin-modules', 'resolve', 'browser-resolve', 'is-module' ],
-	targets: [
-		{ dest: 'dist/rollup-plugin-node-resolve.cjs.js', format: 'cjs' },
-		{ dest: 'dist/rollup-plugin-node-resolve.es.js', format: 'es' }
+	output: [
+		{ file: 'dist/rollup-plugin-node-resolve.cjs.js', format: 'cjs' },
+		{ file: 'dist/rollup-plugin-node-resolve.es.js', format: 'es' }
 	]
 };


### PR DESCRIPTION
This will enable the easy installation of `rollup-plugin-node-resolve` forks from Github via
`npm install <user>/rollup-plugin-node-resolve#<branch>`

Similar changes have already been added to `rollup` and `rollup-plugin-commonjs`.