### PR TITLE
Updated the README.md with the info about jsnext:main

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ export default {
       module: true, // Default: true
 
       // use "jsnext:main" if possible
-      // – see https://github.com/rollup/rollup/wiki/jsnext:main
+      // legacy field pointing to ES6 module in third-party libraries,
+      // deprecated in favor of "pkg.module":
+      // - see: https://github.com/rollup/rollup/wiki/pkg.module
       jsnext: true,  // Default: false
 
       // use "main" field or index.js, even if it's not an ES6 module


### PR DESCRIPTION
The information in the readme is pointing to a non-existent page in the Rollup Wiki: https://github.com/rollup/rollup/wiki/jsnext:main

The situation with `jsnext:main` is never really explained in Rollup docs, so I have added some pointers for people who are confused by `jsnext` setting.

Please feel free to close this if you don't find this PR useful. 😓 