### PR TITLE
Allow customResolveOptions to be a function.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 .gobble*
 !test/node_modules
+!test/node_modules/nesting/node_modules

--- a/README.md
+++ b/README.md
@@ -73,6 +73,21 @@ export default {
 };
 ```
 
+`customResolveOptions` can also be a function instead of an object.  This is used when
+custom options need to be set depending on parameters of the import.  Providing the
+following customResolveOptions function will block use of nested modules by resolving
+the import from to `__dirname`.
+
+```js
+function customResolveOptions(options, id, importer) {
+  console.log('Trying to import package:', id);
+  console.log('Trying to import from source:', importer);
+  if (importer.includes('/node_modules/')) {
+    options.basedir = __dirname;
+  }
+}
+```
+
 ## Using with rollup-plugin-commonjs
 
 Since most packages in your node_modules folder are probably legacy CommonJS rather than JavaScript modules, you may need to use [rollup-plugin-commonjs](https://github.com/rollup/rollup-plugin-commonjs):

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,9 @@ export default function nodeResolve ( options = {} ) {
 	const useJsnext = options.jsnext === true;
 	const isPreferBuiltinsSet = options.preferBuiltins === true || options.preferBuiltins === false;
 	const preferBuiltins = isPreferBuiltinsSet ? options.preferBuiltins : true;
-	const customResolveOptions = options.customResolveOptions || {};
+	const customResolveOptionsIsFn = typeof options.customResolveOptions === 'function';
+	const customResolveFn = customResolveOptionsIsFn ? options.customResolveOptions : null;
+	const customResolveOptions = !customResolveOptionsIsFn && options.customResolveOptions || {};
 	const jail = options.jail;
 	const only = Array.isArray(options.only)
 		? options.only.map(o => o instanceof RegExp
@@ -152,6 +154,10 @@ export default function nodeResolve ( options = {} ) {
 				isFile: cachedIsFile,
 				extensions: extensions
 			};
+
+			if (customResolveOptionsIsFn) {
+				customResolveFn(resolveOptions, id, importer);
+			}
 
 			if (preserveSymlinks !== undefined) {
 				resolveOptions.preserveSymlinks = preserveSymlinks;

--- a/test/node_modules/nested/entry.js
+++ b/test/node_modules/nested/entry.js
@@ -1,0 +1,1 @@
+export default 'ROOT';

--- a/test/node_modules/nested/package.json
+++ b/test/node_modules/nested/package.json
@@ -1,0 +1,3 @@
+{
+	"main": "entry.js"
+}

--- a/test/node_modules/nesting/entry.js
+++ b/test/node_modules/nesting/entry.js
@@ -1,0 +1,2 @@
+import value from 'nested';
+export default value;

--- a/test/node_modules/nesting/node_modules/nested/entry.js
+++ b/test/node_modules/nesting/node_modules/nested/entry.js
@@ -1,0 +1,1 @@
+export default 'NESTED';

--- a/test/node_modules/nesting/node_modules/nested/package.json
+++ b/test/node_modules/nesting/node_modules/nested/package.json
@@ -1,0 +1,3 @@
+{
+	"main": "entry.js"
+}

--- a/test/node_modules/nesting/package.json
+++ b/test/node_modules/nesting/package.json
@@ -1,0 +1,3 @@
+{
+	"main": "entry.js"
+}

--- a/test/samples/nesting/main.js
+++ b/test/samples/nesting/main.js
@@ -1,0 +1,2 @@
+import value from 'nesting';
+export default value;

--- a/test/test.js
+++ b/test/test.js
@@ -157,7 +157,7 @@ describe( 'rollup-plugin-node-resolve', function () {
 
 	it( 'allows use of object browser field, resolving `main`', function () {
 		return rollup.rollup({
-			entry: 'samples/browser-object-main/main.js',
+			input: 'samples/browser-object-main/main.js',
 			plugins: [
 				nodeResolve({
 					main: true,
@@ -173,7 +173,7 @@ describe( 'rollup-plugin-node-resolve', function () {
 
 	it( 'allows use of object browser field, resolving implicit `main`', function () {
 		return rollup.rollup({
-			entry: 'samples/browser-object/main-implicit.js',
+			input: 'samples/browser-object/main-implicit.js',
 			plugins: [
 				nodeResolve({
 					main: true,
@@ -187,7 +187,7 @@ describe( 'rollup-plugin-node-resolve', function () {
 
 	it( 'allows use of object browser field, resolving replaced builtins', function () {
 		return rollup.rollup({
-			entry: 'samples/browser-object-builtin/main.js',
+			input: 'samples/browser-object-builtin/main.js',
 			plugins: [
 				nodeResolve({
 					main: true,
@@ -201,7 +201,7 @@ describe( 'rollup-plugin-node-resolve', function () {
 
 	it( 'allows use of object browser field, resolving nested directories', function () {
 		return rollup.rollup({
-			entry: 'samples/browser-object-nested/main.js',
+			input: 'samples/browser-object-nested/main.js',
 			plugins: [
 				nodeResolve({
 					main: true,
@@ -217,7 +217,7 @@ describe( 'rollup-plugin-node-resolve', function () {
 
 	it( 'allows use of object browser field, resolving `main`', function () {
 		return rollup.rollup({
-			entry: 'samples/browser-object-main/main.js',
+			input: 'samples/browser-object-main/main.js',
 			plugins: [
 				nodeResolve({
 					main: true,
@@ -233,7 +233,7 @@ describe( 'rollup-plugin-node-resolve', function () {
 
 	it( 'allows use of object browser field, resolving implicit `main`', function () {
 		return rollup.rollup({
-			entry: 'samples/browser-object/main-implicit.js',
+			input: 'samples/browser-object/main-implicit.js',
 			plugins: [
 				nodeResolve({
 					main: true,
@@ -247,7 +247,7 @@ describe( 'rollup-plugin-node-resolve', function () {
 
 	it( 'allows use of object browser field, resolving replaced builtins', function () {
 		return rollup.rollup({
-			entry: 'samples/browser-object-builtin/main.js',
+			input: 'samples/browser-object-builtin/main.js',
 			plugins: [
 				nodeResolve({
 					main: true,
@@ -261,7 +261,7 @@ describe( 'rollup-plugin-node-resolve', function () {
 
 	it( 'allows use of object browser field, resolving nested directories', function () {
 		return rollup.rollup({
-			entry: 'samples/browser-object-nested/main.js',
+			input: 'samples/browser-object-nested/main.js',
 			plugins: [
 				nodeResolve({
 					main: true,
@@ -277,7 +277,7 @@ describe( 'rollup-plugin-node-resolve', function () {
 
 	it( 'allows use of object browser field, resolving `main`', function () {
 		return rollup.rollup({
-			entry: 'samples/browser-object-main/main.js',
+			input: 'samples/browser-object-main/main.js',
 			plugins: [
 				nodeResolve({
 					main: true,
@@ -293,7 +293,7 @@ describe( 'rollup-plugin-node-resolve', function () {
 
 	it( 'allows use of object browser field, resolving implicit `main`', function () {
 		return rollup.rollup({
-			entry: 'samples/browser-object/main-implicit.js',
+			input: 'samples/browser-object/main-implicit.js',
 			plugins: [
 				nodeResolve({
 					main: true,
@@ -307,7 +307,7 @@ describe( 'rollup-plugin-node-resolve', function () {
 
 	it( 'allows use of object browser field, resolving replaced builtins', function () {
 		return rollup.rollup({
-			entry: 'samples/browser-object-builtin/main.js',
+			input: 'samples/browser-object-builtin/main.js',
 			plugins: [
 				nodeResolve({
 					main: true,
@@ -321,7 +321,7 @@ describe( 'rollup-plugin-node-resolve', function () {
 
 	it( 'allows use of object browser field, resolving nested directories', function () {
 		return rollup.rollup({
-			entry: 'samples/browser-object-nested/main.js',
+			input: 'samples/browser-object-nested/main.js',
 			plugins: [
 				nodeResolve({
 					main: true,
@@ -539,16 +539,16 @@ describe( 'rollup-plugin-node-resolve', function () {
 	});
 
 	it( 'throws error if local id is not resolved', () => {
-		const entry = path.join( 'samples', 'unresolved-local', 'main.js' );
+		const input = path.join( 'samples', 'unresolved-local', 'main.js' );
 		return rollup.rollup({
-			entry,
+			input,
 			plugins: [
 				nodeResolve()
 			]
 		}).then( () => {
 			throw Error( 'test should fail' );
 		}, err => {
-			assert.equal( err.message, `Could not resolve './foo' from ${entry}` );
+			assert.equal( err.message, `Could not resolve './foo' from ${input}` );
 		});
 	});
 
@@ -616,6 +616,34 @@ describe( 'rollup-plugin-node-resolve', function () {
 		});
 	});
 
+	it( 'allows custom options function to manipulate options', () => {
+		return rollup.rollup({
+			input: 'samples/nesting/main.js',
+			plugins: [ nodeResolve({
+				customResolveOptions (options, id, importer) {
+					switch (id) {
+						case 'nesting':
+							assert.equal(importer, path.join(__dirname, 'samples/nesting/main.js'));
+							break;
+						case 'nested':
+							assert.equal(id, 'nested');
+							assert.equal(importer, path.join(__dirname, 'node_modules/nesting/entry.js'));
+							break;
+						default:
+							assert.fail('Unexpected import ' + id);
+							break;
+					}
+
+					if (importer.startsWith(path.join(__dirname, 'node_modules/'))) {
+						options.basedir = __dirname;
+					}
+				}
+			}) ]
+		}).then( executeBundle ).then( module => {
+			assert.deepEqual( module.exports, 'ROOT' );
+		});
+	});
+
 	it( 'ignores deep-import non-modules', () => {
 		return rollup.rollup({
 			input: 'samples/deep-import-non-module/main.js',
@@ -624,6 +652,15 @@ describe( 'rollup-plugin-node-resolve', function () {
 			}) ]
 		}).then( bundle => {
 			assert.deepEqual( bundle.imports, [ 'foo/deep' ] );
+		});
+	});
+
+	it( 'resolves nested module', () => {
+		return rollup.rollup({
+			input: 'samples/nesting/main.js',
+			plugins: [ nodeResolve({}) ]
+		}).then( executeBundle ).then( module => {
+			assert.deepEqual( module.exports, 'NESTED' );
 		});
 	});
 });


### PR DESCRIPTION
This allows fine grained control over resolve options on a per import
basis.  For each import the function is called, allowing the user of
this module to manipulate options based on the package being imported or
the source performing the import.