### PR TITLE
Ensure imports outside jail are marked as external

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -184,7 +184,7 @@ export default function nodeResolve ( options = {} ) {
 								}
 								fulfil( null );
 							} else if ( jail && resolved.indexOf( normalize( jail.trim( sep ) ) ) !== 0 ) {
-								fulfil( null );
+								fulfil( false );
 							}
 						}
 

--- a/test/test.js
+++ b/test/test.js
@@ -557,7 +557,10 @@ describe( 'rollup-plugin-node-resolve', function () {
 			input: 'samples/jail/main.js',
 			plugins: [ nodeResolve({
 				jail: `${__dirname}/samples/`
-			}) ]
+			}) ],
+			onwarn: (err) => {
+				if ( err.code && err.code === 'UNRESOLVED_IMPORT' ) throw err;
+			}
 		}).then( (bundle) => {
 			assert.deepEqual(bundle.imports, [ 'string/uppercase.js' ]);
 		});


### PR DESCRIPTION
This fixes an issue with dependencies outside the jail not being marked as external.
Because if this Rollup shows warnings for every dependency outside the jail.

This bug was caused by the promise being resolved as `null`, which defers the resolution, instead of `false` which indicates the dependency should be external ([from the plugin documentation](https://github.com/rollup/rollup/wiki/Plugins#creating-plugins)):

> Returning null or undefined defers to other resolveId functions (and eventually the default resolution behavior); returning false signals that importee should be treated as an external module and not included in the bundle.

Because the tests did not check for warnings this was not detected.
