### PR TITLE
Allow browser to be an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ export default {
       // for the browser. If that's you, use this option, otherwise
       // pkg.browser will be ignored
       browser: true,  // Default: false
+      // browser can also be specified as an array of strings and/or regexps
+      // so that only modules that match at least one entry use the browser
+      // field. ex. browser: [ 'some_module', /^@some_scope\/.*$/ ],
 
       // not all files you want to resolve are .js files
       extensions: [ '.mjs', '.js', '.jsx', '.json' ],  // Default: [ '.mjs', '.js', '.json', '.node' ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1621,6 +1621,15 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-capitalize": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-capitalize/-/string-capitalize-1.0.1.tgz",
@@ -1635,15 +1644,6 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/test/test.js
+++ b/test/test.js
@@ -123,6 +123,34 @@ describe( 'rollup-plugin-node-resolve', function () {
 		});
 	});
 
+	it( 'disregards browser field for modules not in browser array', function () {
+		return rollup.rollup({
+			input: 'samples/browser/main.js',
+			plugins: [
+				nodeResolve({
+					main: true,
+					browser: ['not-a-module']
+				})
+			]
+		}).then( executeBundle ).then( module => {
+			assert.equal( module.exports, 'node' );
+		});
+	});
+
+	it( 'allows use of the browser field for module in browser array', function () {
+		return rollup.rollup({
+			input: 'samples/browser/main.js',
+			plugins: [
+				nodeResolve({
+					main: true,
+					browser: ['isomorphic']
+				})
+			]
+		}).then( executeBundle ).then( module => {
+			assert.equal( module.exports, 'browser' );
+		});
+	});
+
 	it( 'disregards object browser field by default', function () {
 		return rollup.rollup({
 			input: 'samples/browser-object/main.js',


### PR DESCRIPTION
This allows the browser field to be used selectively. For my case I have a module that benefits from the browser field in using non-node utils, but then a couple others that also end up using it and losing treeshaking benefits.