### PR TITLE
perf: use new PluginDriver cache

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import builtins from 'builtin-modules';
 import resolveId from 'resolve';
 import isModule from 'is-module';
 import fs from 'fs';
+import packageJSON from '../package.json';
 
 const ES6_BROWSER_EMPTY = resolve( __dirname, '../src/empty.js' );
 const CONSOLE_WARN = ( ...args ) => console.warn( ...args ); // eslint-disable-line no-console
@@ -22,11 +23,31 @@ function cachedReadFile (file, cb) {
 	}
 	readFileCache[file].then(contents => cb(null, contents), cb);
 }
+let statCache = {};
+function cachedStat (file) {
+	if (file in statCache === false) {
+		statCache[file] = statAsync(file).catch(err => {
+			delete statCache[file];
+			throw err;
+		});
+	}
+	return statCache[file];
+}
+
+function getFileCacheEntry (file) {
+	return cachedStat(file).then(({ mtimeMs, size }) => ({ file, mtimeMs, size }), err => ({ file, code: err.code }))
+}
+
+function compareFileCacheEntry (cacheEntry) {
+	return getFileCacheEntry(cacheEntry.file).then(({ mtimeMs, size, code, }) => {
+		return code ? code === cacheEntry.code : mtimeMs === cacheEntry.mtimeMs && size === cacheEntry.size
+	})
+}
 
 let isFileCache = {};
 function cachedIsFile (file, cb) {
 	if (file in isFileCache === false) {
-		isFileCache[file] = statAsync(file)
+		isFileCache[file] = cachedStat(file)
 			.then(
 				stat => stat.isFile(),
 				err => {
@@ -77,6 +98,7 @@ export default function nodeResolve ( options = {} ) {
 
 		onwrite () {
 			isFileCache = {};
+			statCache = {};
 			readFileCache = {};
 		},
 
@@ -86,116 +108,146 @@ export default function nodeResolve ( options = {} ) {
 			// disregard entry module
 			if ( !importer ) return null;
 
-			if (options.browser && browserMapCache[importer]) {
-				const resolvedImportee = resolve( dirname( importer ), importee );
-				const browser = browserMapCache[importer];
-				if (browser[importee] === false || browser[resolvedImportee] === false) {
-					return ES6_BROWSER_EMPTY;
-				}
-				if (browser[importee] || browser[resolvedImportee] || browser[resolvedImportee + '.js'] || browser[resolvedImportee + '.json']) {
-					importee = browser[importee] || browser[resolvedImportee] || browser[resolvedImportee + '.js'] || browser[resolvedImportee + '.json'];
-				}
-			}
+			return Promise.resolve(this.cache ? this.cache.get(`${importee}|${importer}`) : false)
+				.then((cache) => {
+					// If the importer, importee or any package.json files have changed then invalidate the cache:
+					return cache && cache.stats.reduce((promise, cacheEntry) => {
+						return promise.then(stillValid => stillValid && compareFileCacheEntry(cacheEntry), Promise.resolve(true));
+					});
+				}).then(cacheIsValid => {
+					if (cacheIsValid) {
+						return this.cache.get(`${importee}|${importer}`).result;
+					}
+
+					if (options.browser && browserMapCache[importer]) {
+						const resolvedImportee = resolve( dirname( importer ), importee );
+						const browser = browserMapCache[importer];
+						if (browser[importee] === false || browser[resolvedImportee] === false) {
+							return ES6_BROWSER_EMPTY;
+						}
+						if (browser[importee] || browser[resolvedImportee] || browser[resolvedImportee + '.js'] || browser[resolvedImportee + '.json']) {
+							importee = browser[importee] || browser[resolvedImportee] || browser[resolvedImportee + '.js'] || browser[resolvedImportee + '.json'];
+						}
+					}
 
 
-			const parts = importee.split( /[/\\]/ );
-			let id = parts.shift();
+					const parts = importee.split( /[/\\]/ );
+					let id = parts.shift();
 
-			if ( id[0] === '@' && parts.length ) {
-				// scoped packages
-				id += `/${parts.shift()}`;
-			} else if ( id[0] === '.' ) {
-				// an import relative to the parent dir of the importer
-				id = resolve( importer, '..', importee );
-			}
+					if ( id[0] === '@' && parts.length ) {
+						// scoped packages
+						id += `/${parts.shift()}`;
+					} else if ( id[0] === '.' ) {
+						// an import relative to the parent dir of the importer
+						id = resolve( importer, '..', importee );
+					}
 
-			if (only && !only.some(pattern => pattern.test(id))) return null;
+					if (only && !only.some(pattern => pattern.test(id))) return null;
 
-			let disregardResult = false;
-			let packageBrowserField = false;
-			const extensions = options.extensions || DEFAULT_EXTS;
+					let disregardResult = false;
+					let packageBrowserField = false;
+					const extensions = options.extensions || DEFAULT_EXTS;
+					const checkedFiles = new Set();
 
-			const resolveOptions = {
-				basedir: dirname( importer ),
-				packageFilter ( pkg, pkgPath ) {
-					const pkgRoot = dirname( pkgPath );
-					if (options.browser && typeof pkg[ 'browser' ] === 'object') {
-						packageBrowserField = Object.keys(pkg[ 'browser' ]).reduce((browser, key) => {
-							const resolved = pkg[ 'browser' ][ key ] === false ? false : resolve( pkgRoot, pkg[ 'browser' ][ key ] );
-							browser[ key ] = resolved;
-							if ( key[0] === '.' ) {
-								const absoluteKey = resolve( pkgRoot, key );
-								browser[ absoluteKey ] = resolved;
-								if ( !extname(key) ) {
-									extensions.reduce( ( browser, ext ) => {
-										browser[ absoluteKey + ext ] = browser[ key ];
-										return browser;
-									}, browser );
+					const resolveOptions = {
+						basedir: dirname( importer ),
+						packageFilter ( pkg, pkgPath ) {
+							const pkgRoot = dirname( pkgPath );
+							if (options.browser && typeof pkg[ 'browser' ] === 'object') {
+								packageBrowserField = Object.keys(pkg[ 'browser' ]).reduce((browser, key) => {
+									const resolved = pkg[ 'browser' ][ key ] === false ? false : resolve( pkgRoot, pkg[ 'browser' ][ key ] );
+									browser[ key ] = resolved;
+									if ( key[0] === '.' ) {
+										const absoluteKey = resolve( pkgRoot, key );
+										browser[ absoluteKey ] = resolved;
+										if ( !extname(key) ) {
+											extensions.reduce( ( browser, ext ) => {
+												browser[ absoluteKey + ext ] = browser[ key ];
+												return browser;
+											}, browser );
+										}
+									}
+									return browser;
+								}, {});
+							}
+
+							if (options.browser && typeof pkg[ 'browser' ] === 'string') {
+								pkg[ 'main' ] = pkg[ 'browser' ];
+							} else if ( useModule && pkg[ 'module' ] ) {
+								pkg[ 'main' ] = pkg[ 'module' ];
+							} else if ( useJsnext && pkg[ 'jsnext:main' ] ) {
+								pkg[ 'main' ] = pkg[ 'jsnext:main' ];
+							} else if ( ( useJsnext || useModule ) && !useMain ) {
+								disregardResult = true;
+							}
+							return pkg;
+						},
+						readFile (file) {
+							checkedFiles.add(file);
+							return cachedReadFile(file);
+						},
+						isFile (file) {
+							checkedFiles.add(file);
+							return cachedIsFile(file);
+						},
+						extensions: extensions
+					};
+
+					if (preserveSymlinks !== undefined) {
+						resolveOptions.preserveSymlinks = preserveSymlinks;
+					}
+
+					return resolveIdAsync(
+						importee,
+						Object.assign( resolveOptions, customResolveOptions )
+					)
+						.catch(() => false)
+						.then(resolved => {
+							if (options.browser && packageBrowserField) {
+								if (packageBrowserField[ resolved ]) {
+									resolved = packageBrowserField[ resolved ];
+								}
+								browserMapCache[resolved] = packageBrowserField;
+							}
+
+							if ( !disregardResult && resolved !== false ) {
+								if ( !preserveSymlinks && resolved && fs.existsSync( resolved ) ) {
+									resolved = fs.realpathSync( resolved );
+								}
+
+								if ( ~builtins.indexOf( resolved ) ) {
+									return null;
+								} else if ( ~builtins.indexOf( importee ) && preferBuiltins ) {
+									if ( !isPreferBuiltinsSet ) {
+										onwarn(
+											`preferring built-in module '${importee}' over local alternative ` +
+											`at '${resolved}', pass 'preferBuiltins: false' to disable this ` +
+											`behavior or 'preferBuiltins: true' to disable this warning`
+										);
+									}
+									return null;
+								} else if ( jail && resolved.indexOf( normalize( jail.trim( sep ) ) ) !== 0 ) {
+									return null;
 								}
 							}
-							return browser;
-						}, {});
-					}
 
-					if (options.browser && typeof pkg[ 'browser' ] === 'string') {
-						pkg[ 'main' ] = pkg[ 'browser' ];
-					} else if ( useModule && pkg[ 'module' ] ) {
-						pkg[ 'main' ] = pkg[ 'module' ];
-					} else if ( useJsnext && pkg[ 'jsnext:main' ] ) {
-						pkg[ 'main' ] = pkg[ 'jsnext:main' ];
-					} else if ( ( useJsnext || useModule ) && !useMain ) {
-						disregardResult = true;
-					}
-					return pkg;
-				},
-				readFile: cachedReadFile,
-				isFile: cachedIsFile,
-				extensions: extensions
-			};
-
-			if (preserveSymlinks !== undefined) {
-				resolveOptions.preserveSymlinks = preserveSymlinks;
-			}
-
-			return resolveIdAsync(
-				importee,
-				Object.assign( resolveOptions, customResolveOptions )
-			)
-				.catch(() => false)
-				.then(resolved => {
-					if (options.browser && packageBrowserField) {
-						if (packageBrowserField[ resolved ]) {
-							resolved = packageBrowserField[ resolved ];
-						}
-						browserMapCache[resolved] = packageBrowserField;
-					}
-
-					if ( !disregardResult && resolved !== false ) {
-						if ( !preserveSymlinks && resolved && fs.existsSync( resolved ) ) {
-							resolved = fs.realpathSync( resolved );
-						}
-
-						if ( ~builtins.indexOf( resolved ) ) {
-							return null;
-						} else if ( ~builtins.indexOf( importee ) && preferBuiltins ) {
-							if ( !isPreferBuiltinsSet ) {
-								onwarn(
-									`preferring built-in module '${importee}' over local alternative ` +
-									`at '${resolved}', pass 'preferBuiltins: false' to disable this ` +
-									`behavior or 'preferBuiltins: true' to disable this warning`
-								);
+							if ( resolved && options.modulesOnly ) {
+								return readFileAsync( resolved, 'utf-8').then(code => isModule( code ) ? resolved : null);
+							} else {
+								return resolved === false ? null : resolved;
 							}
-							return null;
-						} else if ( jail && resolved.indexOf( normalize( jail.trim( sep ) ) ) !== 0 ) {
-							return null;
-						}
-					}
-
-					if ( resolved && options.modulesOnly ) {
-						return readFileAsync( resolved, 'utf-8').then(code => isModule( code ) ? resolved : null);
-					} else {
-						return resolved === false ? null : resolved;
-					}
+						})
+						.then(resolved => {
+							if (this.cache) {
+								// We need to stat all files that were checked as part of this algorythm
+								// so we can see if they changed the next time we want to read from cache
+								return Promise.all(Array.from(checkedFiles).map(getFileCacheEntry)).then(stats => {
+									this.cache.set(`${importee}|${importer}`, { stats, result: resolved });
+									return resolved;
+								});
+							}
+							return resolved;
+						});
 				});
 		}
 	};


### PR DESCRIPTION
### What?

This is a pre-emptive PR on https://github.com/rollup/rollup/pull/2382 - to help guide the implementation of `PluginDriver.cache`.

### Why?

The intent is to greatly speed up how this plugin works, and also give an idea of how Rollup core might implement a cache layer.

This will speed up resolving because as opposed to reading and stating multiple files, it should reduce the load to just stating files it needs to, and returning the same result.

### How?

This checks to see if `this.cache` exists, and if it does it will attempt to read from that cache. A successful read of the cache is then checked for validity, and returned instead of executing the entire resolve algorithm. If the cache is not present or invalid, then the algorithm is run as normal.

What consitutes a valid cache? Every file that was read as part of the algorithm (this includes files that don't actually exist, but the algorithm needs to check for existence) is stated and the `mtimeMs` and `size` are stored. The validation routine then checks the _cached_ values of those, against a live stat call and compares the result. If any result is different the cache is blown away. In other words if the user changes or adds a `package.json` or `index.js` file, or changes the importee, importer, then the cached result is disregarded as it is assumed unsafe.

It still has to `stat` a lot of files to ensure the cache is valid, but on the other hand, the number of files read is reduced to 0 on a hot cache. This should make a significant difference to resolve times. Even if the cache is marked as invalid, the work is not wasted as all stat calls get cached for the duration of the build and so subsequent stat calls happen with no IO.