### PR TITLE
support esnext module type

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ export default {
   name: 'MyModule',
   plugins: [
     resolve({
+      // use "esnext" if possible
+      // – see http://2ality.com/2017/06/pkg-esnext.html
+      esnext: true,  // Default: false
+
       // use "module" field for ES6 module if possible
       module: true, // Default: true
 

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ function cachedIsFile (file, cb) {
 const resolveIdAsync = (file, opts) => new Promise((fulfil, reject) => resolveId(file, opts, (err, contents) => err ? reject(err) : fulfil(contents)));
 
 export default function nodeResolve ( options = {} ) {
+	const useEsnext = options.esnext === true;
 	const useModule = options.module !== false;
 	const useMain = options.main !== false;
 	const useJsnext = options.jsnext === true;
@@ -62,8 +63,8 @@ export default function nodeResolve ( options = {} ) {
 		throw new Error( 'options.skip is no longer supported — you should use the main Rollup `external` option instead' );
 	}
 
-	if ( !useModule && !useMain && !useJsnext ) {
-		throw new Error( `At least one of options.module, options.main or options.jsnext must be true` );
+	if ( !useEsnext && !useModule && !useMain && !useJsnext ) {
+		throw new Error( `At least one of options.esnext, options.module, options.main or options.jsnext must be true` );
 	}
 
 	let preserveSymlinks;
@@ -139,11 +140,13 @@ export default function nodeResolve ( options = {} ) {
 
 					if (options.browser && typeof pkg[ 'browser' ] === 'string') {
 						pkg[ 'main' ] = pkg[ 'browser' ];
+					} else if ( useEsnext && pkg[ 'esnext' ] ) {
+						pkg[ 'main' ] = pkg[ 'esnext' ];
 					} else if ( useModule && pkg[ 'module' ] ) {
 						pkg[ 'main' ] = pkg[ 'module' ];
 					} else if ( useJsnext && pkg[ 'jsnext:main' ] ) {
 						pkg[ 'main' ] = pkg[ 'jsnext:main' ];
-					} else if ( ( useJsnext || useModule ) && !useMain ) {
+					} else if ( ( useJsnext || useModule || useEsnext ) && !useMain ) {
 						disregardResult = true;
 					}
 					return pkg;


### PR DESCRIPTION
I have a usecase where I need to use the esnext pkg field as suggested by http://2ality.com/2017/06/pkg-esnext.html .

I am developing web components with the help of skatejs, but without polyfills because I only need to support modern chrome. skatejs exports transpiled sources as module, and original code as esnext. 

But the transpiled code does not run on modern browsers because it does not use class inheritance and calls HTMLElement constructor as function instead - which is not legal. So I really need to use the original code as contained in the skatejs package as esnext, controlling myself to which target the entire code packaged by rollup is transpiled.

I would be very happy if you would accept this patch for upstream.