### PR TITLE
Fix pkg.browser mappings issue by specifying a value of `false`

### DIFF
--- a/test/node_modules/isomorphic-object-with-false/lib/client/http-tracker.js
+++ b/test/node_modules/isomorphic-object-with-false/lib/client/http-tracker.js
@@ -1,0 +1,4 @@
+
+module.exports = function(client, announceUrl) {
+	this.name = 'http-tracker'
+}

--- a/test/node_modules/isomorphic-object-with-false/lib/client/udp-tracker.js
+++ b/test/node_modules/isomorphic-object-with-false/lib/client/udp-tracker.js
@@ -1,0 +1,4 @@
+
+module.exports = function(client, announceUrl) {
+	this.name = 'udp-tracker'
+}

--- a/test/node_modules/isomorphic-object-with-false/lib/client/websocket-tracker.js
+++ b/test/node_modules/isomorphic-object-with-false/lib/client/websocket-tracker.js
@@ -1,0 +1,4 @@
+
+module.exports = function(client, announceUrl) {
+	this.name = 'websocket-tracker'
+}

--- a/test/node_modules/isomorphic-object-with-false/lib/index.js
+++ b/test/node_modules/isomorphic-object-with-false/lib/index.js
@@ -1,0 +1,20 @@
+// sample code inspired by npm: bittorrent-tracker-client
+
+var HTTPTracker = require('./client/http-tracker') // empty object in browser
+var UDPTracker = require('./client/udp-tracker') // empty object in browser
+var WebSocketTracker = require('./client/websocket-tracker')
+
+function Client(protocol, announceUrl) {
+	var self = this;
+	if ((protocol === 'http:' || protocol === 'https:') &&
+		typeof HTTPTracker === 'function') {
+		return new HTTPTracker(self, announceUrl)
+	} else if (protocol === 'udp:' && typeof UDPTracker === 'function') {
+		return new UDPTracker(self, announceUrl)
+	} else if ((protocol === 'ws:' || protocol === 'wss:')) {
+		return new WebSocketTracker(self, announceUrl)
+	}
+	this.name = 'NULL';
+}
+
+module.exports = Client

--- a/test/node_modules/isomorphic-object-with-false/lib/subpath/foo/index.js
+++ b/test/node_modules/isomorphic-object-with-false/lib/subpath/foo/index.js
@@ -1,0 +1,2 @@
+var HTTPTracker = require('../../client/http-tracker') // empty object in browser
+module.exports = HTTPTracker

--- a/test/node_modules/isomorphic-object-with-false/package.json
+++ b/test/node_modules/isomorphic-object-with-false/package.json
@@ -1,0 +1,8 @@
+{
+  "main": "./lib/index.js",
+  "browser": {
+    "./lib/common.js": "./lib/common-browser.js",
+    "./lib/client/http-tracker.js": false,
+    "./lib/client/udp-tracker.js": false
+  }
+}

--- a/test/samples/browser-object-with-false/main.js
+++ b/test/samples/browser-object-with-false/main.js
@@ -1,0 +1,15 @@
+import Client from 'isomorphic-object-with-false';
+import HTTPTracker from 'isomorphic-object-with-false/lib/client/http-tracker';
+import ES6_BROWSER_EMPTY from '../../../src/empty';
+import HTTPTrackerWithSubPath from 'isomorphic-object-with-false/lib/subpath/foo';
+
+// do some assert
+
+assert.deepEqual(new Client('ws:'), { name: 'websocket-tracker' })
+assert.deepEqual(new Client('http:'), { name: 'NULL' })
+assert.equal(HTTPTracker, ES6_BROWSER_EMPTY);
+assert.equal(HTTPTrackerWithSubPath, ES6_BROWSER_EMPTY);
+
+
+// expose
+export default "ok"

--- a/test/test.js
+++ b/test/test.js
@@ -657,4 +657,17 @@ describe( 'rollup-plugin-node-resolve', function () {
 		}).then(executeBundle)
 			.then(({exports}) => exports.then(result => assert.equal(result.default, 42)));
 	});
+
+	it( 'pkg.browser with mapping to prevent bundle by specifying a value of false', () => {
+		return rollup.rollup({
+			input: 'samples/browser-object-with-false/main.js',
+			plugins: [
+				nodeResolve({ browser: true }),
+				commonjs()
+			]
+		}).then( executeBundle ).then( module => {
+			assert.equal( module.exports, 'ok' );
+		});
+	});
+
 });


### PR DESCRIPTION
Fix pkg.browser with some maps specifying a value of `false` to ignore a module. (https://github.com/defunctzombie/package-browser-field-spec)

```js
...
"browser": {
    "module-a": false,  // ---->>> map to empty.js
    "./server/only.js": "./shims/server-only.js"
}
```