### PR TITLE
Support browser path false for require without ext

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ export default function nodeResolve ( options = {} ) {
 			if (options.browser && browserMapCache[importer]) {
 				const resolvedImportee = resolve( basedir, importee );
 				const browser = browserMapCache[importer];
-				if (browser[importee] === false || browser[resolvedImportee] === false) {
+				if (browser[importee] === false || browser[resolvedImportee] === false || browser[resolvedImportee + '.js'] === false || browser[resolvedImportee + '.json'] === false) {
 					return ES6_BROWSER_EMPTY;
 				}
 				if (browser[importee] || browser[resolvedImportee] || browser[resolvedImportee + '.js'] || browser[resolvedImportee + '.json']) {


### PR DESCRIPTION
It's pretty common for node modules to use require() without specifying the file extension, so adding this will most likely make a few more libraries work with rollup. One project doing this is for instance `object-assign` which doesn't work currently. https://github.com/substack/object-inspect/issues/18

Considering the line that checks for changed paths below does exactly the same it's probably just an oversight that this was missing.