### PR TITLE
Added dedupe option to prevent bundling the same package multiple times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 .gobble*
 !test/node_modules
+!test/node_modules/react-consumer/node_modules

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ export default {
       // ES2015 modules
       modulesOnly: true, // Default: false
 
+      // Force resolving for these modules to root's node_modules that helps
+      // to prevent bundling the same package multiple times if package is
+      // imported from dependencies.
+      dedupe: [ 'react', 'react-dom' ], // Default: []
+
       // Any additional options that should be passed through
       // to node-resolve
       customResolveOptions: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -61,6 +61,12 @@ interface RollupNodeResolveOptions {
 	 */
 	modulesOnly?: boolean;
 	/**
+	 * Force resolving for these modules to root's node_modules that helps
+	 * to prevent bundling the same package multiple times if package is
+	 * imported from dependencies.
+	 */
+	dedupe?: string[];
+	/**
 	 * Any additional options that should be passed through
 	 * to node-resolve
 	 */

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import {dirname, extname, normalize, resolve, sep} from 'path';
+import {dirname, extname, normalize, resolve, sep, join} from 'path';
 import builtins from 'builtin-modules';
 import resolveId from 'resolve';
 import isModule from 'is-module';
@@ -40,6 +40,7 @@ function cachedIsFile (file, cb) {
 const resolveIdAsync = (file, opts) => new Promise((fulfil, reject) => resolveId(file, opts, (err, contents) => err ? reject(err) : fulfil(contents)));
 
 export default function nodeResolve ( options = {} ) {
+	const dedupe = options.dedupe || [];
 	const useModule = options.module !== false;
 	const useMain = options.main !== false;
 	const useJsnext = options.jsnext === true;
@@ -81,6 +82,10 @@ export default function nodeResolve ( options = {} ) {
 			if ( /\0/.test( importee ) ) return null; // ignore IDs with null character, these belong to other plugins
 
 			const basedir = importer ? dirname( importer ) : process.cwd();
+
+			if (dedupe.indexOf(importee) !== -1) {
+				importee = join(process.cwd(), 'node_modules', importee);
+			}
 
 			// https://github.com/defunctzombie/package-browser-field-spec
 			if (options.browser && browserMapCache[importer]) {

--- a/test/node_modules/react-consumer/index.js
+++ b/test/node_modules/react-consumer/index.js
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export default 'react-consumer:' + React

--- a/test/node_modules/react-consumer/node_modules/react/index.js
+++ b/test/node_modules/react-consumer/node_modules/react/index.js
@@ -1,0 +1,1 @@
+export default 'react:child'

--- a/test/node_modules/react/index.js
+++ b/test/node_modules/react/index.js
@@ -1,0 +1,1 @@
+export default 'react:root'

--- a/test/samples/react-app/main.js
+++ b/test/samples/react-app/main.js
@@ -1,0 +1,4 @@
+import React from 'react'
+import ReactConsumer from 'react-consumer'
+
+export { React, ReactConsumer }

--- a/test/test.js
+++ b/test/test.js
@@ -761,4 +761,34 @@ describe( 'rollup-plugin-node-resolve', function () {
 		});
 	});
 
+	it( 'single module version is bundle if dedupe is set', () => {
+		return rollup.rollup({
+			input: 'samples/react-app/main.js',
+			plugins: [
+				nodeResolve({
+					dedupe: [ 'react' ]
+				})
+			]
+		}).then( executeBundle ).then( module => {
+			assert.deepEqual(module.exports, { 
+				React: 'react:root',
+				ReactConsumer: 'react-consumer:react:root'
+			});
+		});
+	});
+
+	it( 'multiple module versions are bundled if dedupe is not set', () => {
+		return rollup.rollup({
+			input: 'samples/react-app/main.js',
+			plugins: [
+				nodeResolve()
+			]
+		}).then( executeBundle ).then( module => {
+			assert.deepEqual(module.exports, { 
+				React: 'react:root',
+				ReactConsumer: 'react-consumer:react:child'
+			});
+		});
+	});
+
 });


### PR DESCRIPTION
Added dedupe option to prevent bundling the same package multiple times with unit tests

Very useful feature to make sure that specific dependency will be bundled only once and root node_modules version will be used. When npm link is used with a lot of packages it could cause specific package version to be in each package's node_modules and bundling for this scenario will cause that multiple versions of the same package will be bundled even if it is exactly the same version. Usually this is solved by defining package as peer dependency but this package could be also included in devDependencies for tests and this causes it to appear under node_modules.