### PR TITLE
fix: respect setting the deprecated fields "module", "main", and "jsn…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ function getMainFields (options) {
 				// eslint-disable-next-line no-console
 				console.warn(`node-resolve: setting options.${option} is deprecated, please override options.mainFields instead`);
 				if (options[option] === false) {
-					mainFields = mainFields.filter(mainField => mainField === field);
+					mainFields = mainFields.filter(mainField => mainField !== field);
 				} else if (options[option] === true && mainFields.indexOf(field) === -1) {
 					mainFields.push(field);
 				}

--- a/test/samples/prefer-main/main.js
+++ b/test/samples/prefer-main/main.js
@@ -1,0 +1,3 @@
+import entry from 'entries';
+
+export default entry;

--- a/test/test.js
+++ b/test/test.js
@@ -547,6 +547,39 @@ describe( 'rollup-plugin-node-resolve', function () {
 		});
 	});
 
+	it( 'should support disabling "module" field resolution', function () {
+		return rollup.rollup({
+			input: 'samples/prefer-main/main.js',
+			plugins: [
+				nodeResolve({ module: false })
+			]
+		}).then( executeBundle ).then( module => {
+			assert.equal( module.exports, 'MAIN-ENTRY' );
+		});
+	});
+
+	it( 'should support disabling "main" field resolution', function () {
+		return rollup.rollup({
+			input: 'samples/prefer-module/main.js',
+			plugins: [
+				nodeResolve({ main: false })
+			]
+		}).then( executeBundle ).then( module => {
+			assert.equal( module.exports, 'MODULE-ENTRY' );
+		});
+	});
+
+	it( 'should support enabling "jsnext" field resolution', function () {
+		return rollup.rollup({
+			input: 'samples/prefer-module/main.js',
+			plugins: [
+				nodeResolve({ main: false, module: false, jsnext: true })
+			]
+		}).then( executeBundle ).then( module => {
+			assert.equal( module.exports, 'JSNEXT-ENTRY' );
+		});
+	});
+
 	describe( 'symlinks', () => {
 		function createMissingDirectories () {
 			createDirectory( './samples/symlinked/first/node_modules' );


### PR DESCRIPTION
### Description

This fixes an issue where setting any of the following would have zero impact on what fields were referenced.

```js
module.exports = {
  plugins: [
    // The issue also occurred if they were set individually as well.
    resolve({
      main: false,
      module: false,
      jsnext: false
    })
  ]
}
```

### Related Issues

closes #203 