### PR TITLE
Fix TypeScript Typings (rename and export Options interface)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,12 +9,14 @@ export interface Options {
 	 * @default ['module', 'main']
 	 */
 	mainFields?: ['browser', 'esnext', 'module', 'main'],
+
 	/**
 	 * @deprecated use "mainFields" instead
 	 * use "module" field for ES6 module if possible
 	 * @default true
 	 */
 	module?: boolean;
+
 	/**
 	 * @deprecated use "mainFields" instead
 	 * use "jsnext:main" if possible
@@ -24,6 +26,7 @@ export interface Options {
 	 * @default false
 	 */
 	jsnext?: boolean;
+
 	/**
 	 * @deprecated use "mainFields" instead
 	 * use "main" field or index.js, even if it's not an ES6 module
@@ -32,6 +35,7 @@ export interface Options {
 	 * @default true
 	 */
 	main?: boolean;
+
 	/**
 	 * some package.json files have a "browser" field which specifies
 	 * alternative files to load for people bundling for the browser. If
@@ -40,23 +44,27 @@ export interface Options {
 	 * @default false
 	 */
 	browser?: boolean;
+
 	/**
 	 * not all files you want to resolve are .js files
 	 * @default [ '.mjs', '.js', '.json', '.node' ]
 	 */
 	extensions?: ReadonlyArray<string>;
+
 	/**
 	 * whether to prefer built-in modules (e.g. `fs`, `path`) or
 	 * local ones with the same names
 	 * @default true
 	 */
 	preferBuiltins?: boolean;
+
 	/**
 	 * Lock the module search in this path (like a chroot). Module defined
 	 * outside this path will be marked as external
 	 * @default '/'
 	 */
 	jail?: string;
+
 	/**
 	 * Set to an array of strings and/or regexps to lock the module search
 	 * to modules that match at least one entry. Modules not matching any
@@ -64,18 +72,21 @@ export interface Options {
 	 * @default null
 	 */
 	only?: ReadonlyArray<string | RegExp> | null;
+
 	/**
 	 * If true, inspect resolved files to check that they are
 	 * ES2015 modules
 	 * @default false
 	 */
 	modulesOnly?: boolean;
+
 	/**
 	 * Force resolving for these modules to root's node_modules that helps
 	 * to prevent bundling the same package multiple times if package is
 	 * imported from dependencies.
 	 */
 	dedupe?: string[];
+
 	/**
 	 * Any additional options that should be passed through
 	 * to node-resolve

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import {Plugin} from 'rollup';
 import {AsyncOpts} from 'resolve';
 
-interface RollupNodeResolveOptions {
+export interface RollupNodeResolveOptions {
 	/**
 	 * the fields to scan in a package.json to determine the entry point
 	 * if this list contains "browser", overrides specified in "pkg.browser"

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import {Plugin} from 'rollup';
 import {AsyncOpts} from 'resolve';
 
-export interface RollupNodeResolveOptions {
+export interface Options {
 	/**
 	 * the fields to scan in a package.json to determine the entry point
 	 * if this list contains "browser", overrides specified in "pkg.browser"
@@ -86,4 +86,4 @@ export interface RollupNodeResolveOptions {
 /**
  * Locate modules using the Node resolution algorithm, for using third party modules in node_modules
  */
-export default function nodeResolve(options?: RollupNodeResolveOptions): Plugin;
+export default function nodeResolve(options?: Options): Plugin;


### PR DESCRIPTION
Hi, this PR is like a _small following_ of #189.

Before #189 was created, we add to install package `@types/rollup-plugin-node-resolve` ([source](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/fae25f894d0abafce42baaf82ff563d799568bcf/types/rollup-plugin-node-resolve/index.d.ts)) to make this plugin usable in a TypeScript environment.

The typings exported an interface `Options`, so I did the same here to minimize code updates for people that use `import { Options } from 'rollup-plugin-node-resolve'`.

Thanks :)