### PR TITLE
fix mainFields typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ interface RollupNodeResolveOptions {
 	 * will be used
 	 * @default ['module', 'main']
 	 */
-	mainFields?: ['browser', 'esnext', 'module', 'main'],
+	mainFields?: string[],
 	/**
 	 * @deprecated use "mainFields" instead
 	 * use "module" field for ES6 module if possible


### PR DESCRIPTION
mainFields typing currently accept only a fixed array of value ['browser', 'esnext', 'module', 'main'] but it should accept any array of string.