### PR TITLE
perf: add cached version of `isDir`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,17 +12,17 @@ const DEFAULT_EXTS = [ '.mjs', '.js', '.json', '.node' ];
 const readFileAsync = file => new Promise((fulfil, reject) => fs.readFile(file, (err, contents) => err ? reject(err) : fulfil(contents)));
 const statAsync = file => new Promise((fulfil, reject) => fs.stat(file, (err, contents) => err ? reject(err) : fulfil(contents)));
 const cache = fn => {
-	let cache = Object.create(null);
-	const wrapped = (s, cb = false) => {
-		if (s in cache === false) {
-			cache[s] = fn(s).catch(err => {
-				delete cache[s];
+	const cache = new Map();
+	const wrapped = (fileName, cb) => {
+		if (cache.has(fileName) === false) {
+			cache.set(fileName, fn(fileName).catch(err => {
+				cache.delete(fileName);
 				throw err;
-			});
+			}));
 		}
-		return cb ? cache[s].then(v => cb(null, v), cb) : cache[s];
+		return cache.get(fileName).then(v => cb(null, v), cb);
 	};
-	wrapped.clear = () => { cache = {}; };
+	wrapped.clear = () => cache.clear();
 	return wrapped;
 };
 const ignoreENOENT = err => {

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,22 @@ function cachedIsFile (file, cb) {
 	isFileCache[file].then(contents => cb(null, contents), cb);
 }
 
+let isDirCache = {};
+function cachedIsDir (dir, cb) {
+	if (dir in isDirCache === false) {
+		isDirCache[dir] = statAsync(dir)
+			.then(
+				stat => stat.isDirectory(),
+				err => {
+					if (err.code === 'ENOENT') return false;
+					delete isDirCache[dir];
+					throw err;
+				});
+	}
+	isDirCache[dir].then(contents => cb(null, contents), cb);
+}
+
+
 function getMainFields (options) {
 	let mainFields;
 	if (options.mainFields) {
@@ -182,6 +198,7 @@ export default function nodeResolve ( options = {} ) {
 				},
 				readFile: cachedReadFile,
 				isFile: cachedIsFile,
+				isDir: cachedIsDir,
 				extensions: extensions
 			};
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,14 +13,14 @@ const readFileAsync = file => new Promise((fulfil, reject) => fs.readFile(file, 
 const statAsync = file => new Promise((fulfil, reject) => fs.stat(file, (err, contents) => err ? reject(err) : fulfil(contents)));
 const cache = fn => {
 	const cache = new Map();
-	const wrapped = (fileName, cb) => {
-		if (cache.has(fileName) === false) {
-			cache.set(fileName, fn(fileName).catch(err => {
-				cache.delete(fileName);
+	const wrapped = (param, done) => {
+		if (cache.has(param) === false) {
+			cache.set(param, fn(param).catch(err => {
+				cache.delete(param);
 				throw err;
 			}));
 		}
-		return cache.get(fileName).then(v => cb(null, v), cb);
+		return cache.get(param).then(result => done(null, result), done);
 	};
 	wrapped.clear = () => cache.clear();
 	return wrapped;


### PR DESCRIPTION
We cache `isFile` and `readFile`, but the `resolve` package also allows us to override the `isDir` function - which we can add our caching to to make performance better.