### PR TITLE
chore: upgrade resolve@1.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2930,9 +2930,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
-      "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
       "requires": {
         "path-parse": "^1.0.6"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/resolve": "0.0.8",
     "builtin-modules": "^3.1.0",
     "is-module": "^1.0.0",
-    "resolve": "^1.10.1",
+    "resolve": "^1.11.0",
     "rollup-pluginutils": "^2.7.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This upgrades `resolve` to 1.11.0 which brings performance improvements by checking directories more often - instead of hunting for multiple files in a directory that doesn't exist. See https://github.com/browserify/resolve/issues/116 for more info. 