### PR TITLE
5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # rollup-plugin-node-resolve changelog
 
+## 5.0.1 (2019-05-31)
+
+* Upgrade `resolve` module ([#220](https://github.com/rollup/rollup-plugin-node-resolve/pull/220) by @keithamus)
+
 ## 5.0.0 (2019-05-15)
 
 * Replace bublé with babel, update dependencies ([#216](https://github.com/rollup/rollup-plugin-node-resolve/pull/216) by @mecurc)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-node-resolve",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2930,9 +2930,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
-      "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
       "requires": {
         "path-parse": "^1.0.6"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/resolve": "0.0.8",
     "builtin-modules": "^3.1.0",
     "is-module": "^1.0.0",
-    "resolve": "^1.10.1",
+    "resolve": "^1.11.0",
     "rollup-pluginutils": "^2.7.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rollup-plugin-node-resolve",
   "description": "Bundle third-party dependencies in node_modules",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "devDependencies": {
     "@babel/core": "7.4.4",
     "@babel/preset-env": "^7.4.4",


### PR DESCRIPTION
This bumps the package to 5.0.1 - this is needed as the `resolve` module bumped in #200 has no effect due to its source being compiled into this plugin.

I'm not entirely sure if this should be a 5.1.0 or a 5.0.1 🤷‍♂ 