### PR TITLE
fix(): make empty.js virtual

### DIFF
--- a/src/empty.js
+++ b/src/empty.js
@@ -1,1 +1,0 @@
-export default {};

--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,9 @@ import fs from 'fs';
 import {createFilter} from 'rollup-pluginutils';
 import {peerDependencies} from '../package.json';
 
-const builtins = builtinList.reduce((set, id) => set.add(id), new Set());
+const builtins = new Set(builtinList);
 
-const ES6_BROWSER_EMPTY = resolve( __dirname, '../src/empty.js' );
+const ES6_BROWSER_EMPTY = '!node-resolve:empty.js';
 // It is important that .mjs occur before .js so that Rollup will interpret npm modules
 // which deploy both ESM .mjs and CommonJS .js files as ESM.
 const DEFAULT_EXTS = [ '.mjs', '.js', '.json', '.node' ];
@@ -91,7 +91,7 @@ export default function nodeResolve ( options = {} ) {
 			: new RegExp('^' + String(o).replace(/[\\^$*+?.()|[\]{}]/g, '\\$&') + '$')
 		)
 		: null;
-	const browserMapCache = {};
+	const browserMapCache = new Map();
 
 	if ( options.skip ) {
 		throw new Error( 'options.skip is no longer supported — you should use the main Rollup `external` option instead' );
@@ -179,6 +179,10 @@ export default function nodeResolve ( options = {} ) {
 		},
 
 		resolveId ( importee, importer ) {
+			if (importee === ES6_BROWSER_EMPTY) {
+				return importee;
+			}
+
 			if ( /\0/.test( importee ) ) return null; // ignore IDs with null character, these belong to other plugins
 
 			const basedir = importer ? dirname( importer ) : process.cwd();
@@ -188,21 +192,22 @@ export default function nodeResolve ( options = {} ) {
 			}
 
 			// https://github.com/defunctzombie/package-browser-field-spec
-			if (useBrowserOverrides && browserMapCache[importer]) {
+			const browser = browserMapCache.get(importer);
+			if (useBrowserOverrides && browser) {
 				const resolvedImportee = resolve( basedir, importee );
-				const browser = browserMapCache[importer];
 				if (browser[importee] === false || browser[resolvedImportee] === false) {
 					return ES6_BROWSER_EMPTY;
 				}
-				if (browser[importee] || browser[resolvedImportee] || browser[resolvedImportee + '.js'] || browser[resolvedImportee + '.json']) {
-					importee = browser[importee] || browser[resolvedImportee] || browser[resolvedImportee + '.js'] || browser[resolvedImportee + '.json'];
+				const browserImportee = browser[importee] || browser[resolvedImportee] || browser[resolvedImportee + '.js'] || browser[resolvedImportee + '.json'];
+				if (browserImportee) {
+					importee = browserImportee;
 				}
 			}
 
 			const parts = importee.split( /[/\\]/ );
 			let id = parts.shift();
 
-			if ( id[0] === '@' && parts.length ) {
+			if ( id[0] === '@' && parts.length > 0 ) {
 				// scoped packages
 				id += `/${parts.shift()}`;
 			} else if ( id[0] === '.' ) {
@@ -261,12 +266,12 @@ export default function nodeResolve ( options = {} ) {
 					if ( resolved && packageBrowserField ) {
 						if ( packageBrowserField.hasOwnProperty(resolved) ) {
 							if (!packageBrowserField[resolved]) {
-								browserMapCache[resolved] = packageBrowserField;
+								browserMapCache.set(resolved, packageBrowserField);
 								return ES6_BROWSER_EMPTY;
 							}
 							resolved = packageBrowserField[ resolved ];
 						}
-						browserMapCache[resolved] = packageBrowserField;
+						browserMapCache.set(resolved, packageBrowserField);
 					}
 
 					if ( hasPackageEntry ) {
@@ -298,6 +303,13 @@ export default function nodeResolve ( options = {} ) {
 					}
 				})
 				.catch(() => null);
-		}
+		},
+
+		load ( importee ) {
+			if ( importee === ES6_BROWSER_EMPTY ) {
+				return 'export default {};';
+			}
+			return null;
+		},
 	};
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import {peerDependencies} from '../package.json';
 
 const builtins = new Set(builtinList);
 
-const ES6_BROWSER_EMPTY = '!node-resolve:empty.js';
+const ES6_BROWSER_EMPTY = '\0node-resolve:empty.js';
 // It is important that .mjs occur before .js so that Rollup will interpret npm modules
 // which deploy both ESM .mjs and CommonJS .js files as ESM.
 const DEFAULT_EXTS = [ '.mjs', '.js', '.json', '.node' ];

--- a/test/samples/browser-object-with-false/main.js
+++ b/test/samples/browser-object-with-false/main.js
@@ -1,6 +1,6 @@
 import Client from 'isomorphic-object-with-false';
 import HTTPTracker from 'isomorphic-object-with-false/lib/client/http-tracker';
-import ES6_BROWSER_EMPTY from '!node-resolve:empty.js';
+import ES6_BROWSER_EMPTY from '\0node-resolve:empty.js';
 import HTTPTrackerWithSubPath from 'isomorphic-object-with-false/lib/subpath/foo';
 
 // do some assert

--- a/test/samples/browser-object-with-false/main.js
+++ b/test/samples/browser-object-with-false/main.js
@@ -1,6 +1,6 @@
 import Client from 'isomorphic-object-with-false';
 import HTTPTracker from 'isomorphic-object-with-false/lib/client/http-tracker';
-import ES6_BROWSER_EMPTY from '../../../src/empty';
+import ES6_BROWSER_EMPTY from '!node-resolve:empty.js';
 import HTTPTrackerWithSubPath from 'isomorphic-object-with-false/lib/subpath/foo';
 
 // do some assert


### PR DESCRIPTION
At stencil we try to make rollup and this plugin to work in the browser, in addition, we bundle rollup-plugin-node-resolve into the stencil's bundle. The fact that `empty.js` is a read file within the file system makes it harder in some cases.

This PR solves that by making the empty.js file a virtual module.