### PR TITLE
doc: fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ import builtins from 'builtin-modules'
 export default ({
   input: ...,
   plugins: [resolve()],
-  externals: builtins,
+  external: builtins,
   output: ...
 })
 ```


### PR DESCRIPTION
Without this:

```text
(!) You have passed an unrecognized option
Unknown input option: externals. Allowed options: acorn, acornInjectPlugins, cache, chunkGroupingSize, context, experimentalCacheExpiry, experimentalOptimizeChunks, experimentalTopLevelAwait, external, inlineDynamicImports, input, manualChunks, moduleContext, onwarn, perf, plugins, preserveModules, preserveSymlinks, shimMissingExports, strictDeprecations, treeshake, watch
```