### PR TITLE
Add getPackageInfoForId API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -204,7 +204,8 @@ export default function nodeResolve ( options = {} ) {
 			packageInfo.resolvedEntryPoint = browserMap[pkg.main];
 			packageInfo.browserMappedMain = true;
 		} else {
-			packageInfo.resolvedEntryPoint = resolve(pkgRoot, pkg.main);
+			// index.node is technically a valid default entrypoint as well...
+			packageInfo.resolvedEntryPoint = resolve(pkgRoot, pkg.main || 'index.js');
 			packageInfo.browserMappedMain = false;
 		}
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import {dirname, extname, join, normalize, resolve, sep} from 'path';
 import builtinList from 'builtin-modules';
 import resolveId from 'resolve';
 import isModule from 'is-module';
-import fs from 'fs';
+import fs, { realpathSync } from 'fs';
 import {createFilter} from 'rollup-pluginutils';
 import {peerDependencies} from '../package.json';
 
@@ -129,6 +129,7 @@ export default function nodeResolve ( options = {} ) {
 
 	const extensions = options.extensions || DEFAULT_EXTS;
 	const packageInfoCache = new Map();
+	const idToPackageInfo = new Map();
 
 	const shouldDedupe = typeof dedupe === 'function'
 		? dedupe
@@ -140,17 +141,39 @@ export default function nodeResolve ( options = {} ) {
 		}
 		const pkgRoot = dirname( pkgPath );
 
+		const packageInfo = {
+			// copy as we are about to munge the `main` field of `pkg`.
+			packageJson: Object.assign({}, pkg),
+
+			// resolve doesn't handle preserveSymlinks for us in this callback
+			packageJsonPath: preserveSymlinks ? pkgPath : realpathSync(pkgPath),
+			
+			// directory containing the package.json
+			root: preserveSymlinks ? pkgPath : realpathSync(pkgRoot),
+
+			// which main field was used during resolution of this module (main, module, or browser)
+			resolvedMainField: 'main',
+
+			// whether the browser map was used to resolve the entry point to this module
+			browserMappedMain: false,
+
+			// the entry point of the module with respect to the selected main field and any
+			// relevant browser mappings.
+			resolvedEntryPoint: ''
+		};
+
 		let overriddenMain = false;
 		for ( let i = 0; i < mainFields.length; i++ ) {
 			const field = mainFields[i];
 			if ( typeof pkg[ field ] === 'string' ) {
 				pkg[ 'main' ] = pkg[ field ];
+				packageInfo.resolvedMainField = field;
 				overriddenMain = true;
 				break;
 			}
 		}
 
-		const packageInfo = {
+		const internalPackageInfo = {
 			cachedPkg: pkg,
 			hasModuleSideEffects: alwaysNull,
 			hasPackageEntry: overriddenMain !== false || mainFields.indexOf( 'main' ) !== -1,
@@ -172,18 +195,28 @@ export default function nodeResolve ( options = {} ) {
 						}
 					}
 					return browser;
-				}, {})
+				}, {}),
+			packageInfo
 		};
+
+		const browserMap = internalPackageInfo.packageBrowserField;
+		if (useBrowserOverrides && typeof pkg['browser'] === 'object' && browserMap.hasOwnProperty(pkg.main)) {
+			packageInfo.resolvedEntryPoint = browserMap[pkg.main];
+			packageInfo.browserMappedMain = true;
+		} else {
+			packageInfo.resolvedEntryPoint = resolve(pkgRoot, pkg.main);
+			packageInfo.browserMappedMain = false;
+		}
 
 		const packageSideEffects = pkg['sideEffects'];
 		if (typeof packageSideEffects === 'boolean') {
-			packageInfo.hasModuleSideEffects = () => packageSideEffects;
+			internalPackageInfo.hasModuleSideEffects = () => packageSideEffects;
 		} else if (Array.isArray(packageSideEffects)) {
-			packageInfo.hasModuleSideEffects = createFilter(packageSideEffects, null, {resolve: pkgRoot});
+			internalPackageInfo.hasModuleSideEffects = createFilter(packageSideEffects, null, {resolve: pkgRoot});
 		}
 
-		packageInfoCache.set(pkgPath, packageInfo);
-		return packageInfo;
+		packageInfoCache.set(pkgPath, internalPackageInfo);
+		return internalPackageInfo;
 	}
 
 	let preserveSymlinks;
@@ -253,13 +286,15 @@ export default function nodeResolve ( options = {} ) {
 			let hasModuleSideEffects = alwaysNull;
 			let hasPackageEntry = true;
 			let packageBrowserField = false;
+			let packageInfo = undefined;
 
 			const resolveOptions = {
 				basedir,
 				packageFilter ( pkg, pkgPath ) {
 					let cachedPkg;
-					({cachedPkg, hasModuleSideEffects, hasPackageEntry, packageBrowserField} =
+					({packageInfo, cachedPkg, hasModuleSideEffects, hasPackageEntry, packageBrowserField} =
 						getCachedPackageInfo(pkg, pkgPath));
+					
 					return cachedPkg;
 				},
 				readFile: readFileCached,
@@ -297,7 +332,6 @@ export default function nodeResolve ( options = {} ) {
 			}
 
 			importSpecifierList.push(importee);
-
 			return resolveImportSpecifiers(
 				importSpecifierList,
 				Object.assign(resolveOptions, customResolveOptions)
@@ -321,6 +355,8 @@ export default function nodeResolve ( options = {} ) {
 					return resolved;
 				})
 				.then(resolved => {
+					idToPackageInfo.set(resolved, packageInfo);
+
 					if ( hasPackageEntry ) {
 						if (builtins.has(resolved) && preferBuiltins && isPreferBuiltinsSet) {
 							return null;
@@ -354,5 +390,9 @@ export default function nodeResolve ( options = {} ) {
 			}
 			return null;
 		},
+
+		getPackageInfoForId (id) {
+			return idToPackageInfo.get(id);
+		}
 	};
 }

--- a/src/index.js
+++ b/src/index.js
@@ -139,17 +139,23 @@ export default function nodeResolve ( options = {} ) {
 		if (packageInfoCache.has(pkgPath)) {
 			return packageInfoCache.get(pkgPath);
 		}
+
+		// browserify/resolve doesn't realpath paths returned in its packageFilter callback
+		if (!preserveSymlinks) {
+			pkgPath = realpathSync(pkgPath);
+		}
+
 		const pkgRoot = dirname( pkgPath );
 
 		const packageInfo = {
 			// copy as we are about to munge the `main` field of `pkg`.
 			packageJson: Object.assign({}, pkg),
 
-			// resolve doesn't handle preserveSymlinks for us in this callback
-			packageJsonPath: preserveSymlinks ? pkgPath : realpathSync(pkgPath),
+			// path to package.json file
+			packageJsonPath: pkgPath,
 			
 			// directory containing the package.json
-			root: preserveSymlinks ? pkgPath : realpathSync(pkgRoot),
+			root: pkgRoot,
 
 			// which main field was used during resolution of this module (main, module, or browser)
 			resolvedMainField: 'main',

--- a/test/test.js
+++ b/test/test.js
@@ -930,7 +930,7 @@ describe( 'rollup-plugin-node-resolve', function () {
 		})
 	);
 
-	describe.only('getPackageInfoForId', () => {
+	describe('getPackageInfoForId', () => {
 		it('populates info for main', () => {
 			const resolve = nodeResolve({
 				mainFields: ['main']
@@ -953,12 +953,14 @@ describe( 'rollup-plugin-node-resolve', function () {
 			}).then(() => {
 				const entriesPkgJsonPath = path.resolve(__dirname, './node_modules/entries/package.json');
 				const root = path.dirname(entriesPkgJsonPath);
-				assert.equal(entriesInfo.browserMappedMain, false);
-				assert.equal(entriesInfo.resolvedMainField, 'main');
-				assert.deepEqual(entriesInfo.packageJson, require(entriesPkgJsonPath));
-				assert.equal(entriesInfo.packageJsonPath, entriesPkgJsonPath);
-				assert.equal(entriesInfo.root, root);
-				assert.equal(entriesInfo.resolvedEntryPoint, path.resolve(root, './main-entry.js'));
+				assert.deepStrictEqual(entriesInfo, {
+					browserMappedMain: false,
+					resolvedMainField: 'main',
+					packageJson: require(entriesPkgJsonPath),
+					packageJsonPath: entriesPkgJsonPath,
+					root,
+					resolvedEntryPoint: path.resolve(root, './main-entry.js')
+				});
 			});
 		});
 
@@ -984,16 +986,19 @@ describe( 'rollup-plugin-node-resolve', function () {
 			}).then(() => {
 				const entriesPkgJsonPath = path.resolve(__dirname, './node_modules/entries/package.json');
 				const root = path.dirname(entriesPkgJsonPath);
-				assert.equal(entriesInfo.browserMappedMain, false);
-				assert.equal(entriesInfo.resolvedMainField, 'module');
-				assert.deepEqual(entriesInfo.packageJson, require(entriesPkgJsonPath));
-				assert.equal(entriesInfo.packageJsonPath, entriesPkgJsonPath);
-				assert.equal(entriesInfo.root, root);
-				assert.equal(entriesInfo.resolvedEntryPoint, path.resolve(root, './module-entry.js'));
+
+				assert.deepStrictEqual(entriesInfo, {
+					browserMappedMain: false,
+					resolvedMainField: 'module',
+					packageJson: require(entriesPkgJsonPath),
+					packageJsonPath: entriesPkgJsonPath,
+					root,
+					resolvedEntryPoint: path.resolve(root, './module-entry.js')
+				});
 			});
 		});
 
-		it.only('populates info for browser', () => {
+		it('populates info for browser', () => {
 			const resolve = nodeResolve({
 				mainFields: ['browser']
 			});
@@ -1018,14 +1023,15 @@ describe( 'rollup-plugin-node-resolve', function () {
 				const expectedPkgJson = require(entriesPkgJsonPath);
 
 				for (const entriesInfo of entriesInfoMap.values()) {
-					assert.equal(entriesInfo.browserMappedMain, true);
-					assert.equal(entriesInfo.resolvedMainField, 'main');
-					assert.deepEqual(entriesInfo.packageJson, expectedPkgJson);
-					assert.equal(entriesInfo.packageJsonPath, entriesPkgJsonPath);
-					assert.equal(entriesInfo.root, root);
-					assert.equal(entriesInfo.resolvedEntryPoint, path.resolve(root, './browser.js'));
+					assert.deepStrictEqual(entriesInfo, {
+						browserMappedMain: true,
+						resolvedMainField: 'main',
+						packageJson: expectedPkgJson,
+						packageJsonPath: entriesPkgJsonPath,
+						root,
+						resolvedEntryPoint: path.resolve(root, './browser.js')
+					});
 				}
-
 			});
 		});
 		


### PR DESCRIPTION
It is often helpful for other plugins to get a module id's associated package.json. For example, rollup-plugin-commonjs wants at to at least:

1. Consult package.json for its module name in order to know whether a user has configured named exports for that module.
2. Consult package.json's types field to infer exported members from TS type information.

Unfortunately, finding a package.json given a module id is slow and error prone, and shouldn't really be done by each plugin since this plugin has already loaded the package.json during its resolution process.

So this PR exposes an new plugin API, `getPackageInfoForId`, which contains the following information:

* packageJson: the original package json file (unmunged, and so different than its internal package json cache).
* packageJsonPath: path to the containing module's package.json
* root: package root directory
* resolvedMainField: the main field used during resolution, either 'main', 'browser', or 'module'.
* browserMappedMain: whether the browser map was used to find the entry point
* resolvedEntryPoint: the entry point after all mappings were applied

Note this bit of complexity: you can end up with `resolvedMainField` as `main` while `browserMappedMain` is true and `resolvedEntryPoint` is browser-mapped. This happens when a package uses a `browser` map object (rather than just a string) that happens to map `main` or `module`.

/cc @lukastaegert since this was your idea, appreciate a review 😁